### PR TITLE
Sort macro definitions by alphabet

### DIFF
--- a/doc/TODO.md
+++ b/doc/TODO.md
@@ -46,6 +46,12 @@ TODO LISTS
 
 + 1. Tag_ReachParameter问题
 
+### KINWAVSED_OL模块
+
++ 1. mdi.AddInput("QRECH", "m3/s", "Flux in the downslope boundary of cells", "Module",DT_Array2D); QRECH变量名与MUSK_CH中河道出口流量冲突，而且DimensionType也不相符
++ 
+
+
 ### MUSLE_AS模块
 
 + 1. SEDTOCH和SEDTOCH_T单位到底是吨还是千克？

--- a/src/base/util/text.h
+++ b/src/base/util/text.h
@@ -328,386 +328,379 @@
 
 //////////////////////////////////////////////////////////////////////////
 /// Define unit names common used in SEIMS, in case of inconsistency /////
-/// By Huiran Gao, May 19, 2016  //////////////////////////////////////
+/// By LiangJun Zhu, HuiRan Gao ///
+///Apr. , 2016  //////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
-
-#define VAR_DEPREIN "Depre_in"                           /// initial depression storage coefficient
-#define VAR_DEPRESSION "Depression"                      /// Depression storage capacity
-#define VAR_INET "INET"                                  /// evaporation from the interception storage obtained from the interception module
-#define VAR_PET "PET"                                    /// PET calculated from the spatial interpolation module
-#define VAR_EXCP "EXCP"                                  /// excess precipitation calculated in the infiltration module
-#define VAR_INFIL "INFIL"                                /// Infiltration calculated in the infiltration module
-#define VAR_DPST "DPST"                                  /// Distribution of depression storage
-#define VAR_DEET "DEET"                                  /// Distribution of evaporation from depression storage
-#define VAR_GW0 "GW0"                                    /// initial ground water storage
-#define VAR_GWMAX "GWMAX"                                /// maximum ground water storage
-#define VAR_DF_COEF "df_coef"                            /// Deep percolation coefficient
-#define VAR_KG "Kg"                                      /// Baseflow recession coefficient
-#define VAR_Base_ex "Base_ex"                            /// baseflow recession exponent
-#define VAR_SUBBSN "subbasin"                            /// The subbasin grid
-#define VAR_PERCO "Percolation"                          /// the amount of water percolated from the soil water reservoir
-#define VAR_SOMO "SOMO"                                  /// Distribution of soil moisture
-#define VAR_DEET "DEET"                                  /// evaporation from the depression storage
-#define VAR_SOET "SOET"                                  /// evaporation from the soil water storage
-#define VAR_GWNEW "GWNEW"                                /// The volume of water from the bank storage to the adjacent unsaturated zone and groundwater storage
-#define VAR_GWWB "GWWB"                                  /// 
-#define VAR_REVAP "Revap"                                /// 
-#define VAR_RG "RG"                                      /// 
-#define VAR_SBQG "SBQG"                                  /// 
-#define VAR_SBPET "SBPET"                                /// 
-#define VAR_SBGS "SBGS"                                  /// 
-#define VAR_K_CHB "K_chb"                                /// hydraulic conductivity of the channel bed
-#define VAR_K_BANK "K_bank"                              /// hydraulic conductivity of the channel bank
-#define VAR_EP_CH "Ep_ch"                               /// reach evaporation adjustment factor
-#define VAR_BNK0 "Bnk0"                               /// initial bank storage per meter of reach length
-#define VAR_CHS0 "Chs0"                               /// initial channel storage per meter of reach length
-#define VAR_VSEEP0 "Vseep0"                               ///  the initial volume of transmission loss to the deep aquifer over the time interval
 #define VAR_A_BNK "a_bnk"                               /// bank flow recession constant
+#define VAR_ACC "acc"
+#define VAR_ADDRNH3 "addrnh3"                       /// ammonium added by rainfall (kg/km2)
+#define VAR_ADDRNO3 "addrno3"                       /// nitrate added by rainfall (kg/km2)
 #define VAR_B_BNK "b_bnk"                               /// bank storage loss coefficient
-#define VAR_MSK_X "MSK_X"                               /// muskingum weighing factor
-#define VAR_MSK_CO1 "MSK_co1"                               /// Weighting factor of bankful flow
-#define VAR_VDIV "Vdiv"                               /// diversion loss of the river reach
-#define VAR_VPOINT "Vpoint"                               /// point source discharge
-#define VAR_MSF "ManningScaleFactor"                               /// flow velocity scaling factor for calibration
-#define VAR_VSF "VelScaleFactor"                               /// flow velocity scaling factor for calibration
-#define VAR_SBOF "SBOF"                               /// overland flow to streams from each subbasin
-#define VAR_SBIF "SBIF"                               /// interflow to streams from each subbasin
-#define VAR_SBQG "SBQG"                               /// groundwater flow out of the subbasin
-#define VAR_SBPET "SBPET"                               /// the potential evapotranspiration rate of the subbasin
-#define VAR_SBGS "SBGS"                               /// Groundwater storage of the subbasin
-#define VAR_QRECH "QRECH"                               /// Discharge in a text format at each reach outlet and at each time step
-#define VAR_QOUTLET "QOUTLET"                               /// discharge at the watershed outlet
-#define VAR_QSOUTLET "QSOUTLET"                               /// discharge at the watershed outlet
-#define VAR_QS "QS"                               /// Overland discharge at each reach outlet and at each time step
-#define VAR_QI "QI"                               /// Interflow at each reach outlet and at each time step
-#define VAR_QG "QG"                               /// Groundwater discharge at each reach outlet and at each time step
-#define VAR_CHST "CHST"                               /// channel storage
+#define VAR_Base_ex "Base_ex"                            /// baseflow recession exponent
 #define VAR_BKST "BKST"                               /// bank storage
-#define VAR_SEEPAGE "SEEPAGE"                               /// seepage
-#define VAR_CHWTDEPTH "CHWTDEPTH"                               /// channel water depth
-#define VAR_QUPREACH "QUPREACH"                               /// upreach
-#define VAR_OL_IUH "Ol_iuh"                               /// IUH of each grid cell
-#define VAR_SSRU "SSRU"                               /// The subsurface runoff
+#define VAR_BNK0 "Bnk0"                               /// initial bank storage per meter of reach length
 #define VAR_C_WABA "C_WABA"                               /// Channel water balance in a text format for each reach and at each time step
 #define VAR_CDN "cdn"                               /// rate coefficient for denitrification
-
-#define DESC_DEPREIN "initial depression storage coefficient"
-#define DESC_DEPRESSION "Depression storage capacity"
-#define DESC_INET "evaporation from the interception storage obtained from the interception module"
-#define DESC_PET "PET calculated from the spatial interpolation module"
-#define DESC_EXCP "excess precipitation calculated in the infiltration module"
-#define DESC_INFIL "Infiltration calculated in the infiltration module"
-#define DESC_DPST "Distribution of depression storage"
-#define DESC_DEET "Distribution of evaporation from depression storage"
-#define DESC_TIMESTEP "time step"
-#define DESC_GW0 "initial ground water storage"
-#define DESC_GWMAX "maximum ground water storage"
-#define DESC_DF_COEF "Deep percolation coefficient"
-#define DESC_KG "Baseflow recession coefficient"
-#define DESC_BASE_EX "baseflow recession exponent"
-#define DESC_SUBBSN "The subbasion grid"
-#define DESC_PERCO "the amount of water percolated from the soil water reservoir"
-#define DESC_SOMO "Distribution of soil moisture"
-#define DESC_DEET "evaporation from the depression storage"
-#define DESC_SOET "evaporation from the soil water storage"
-#define DESC_GWNEW "The volume of water from the bank storage to the adjacent unsaturated zone and groundwater storage"
-#define DESC_K_CHB "hydraulic conductivity of the channel bed"
-#define DESC_K_BANK "hydraulic conductivity of the channel bank"
-#define DESC_EP_CH "reach evaporation adjustment factor"
-#define DESC_BNK0 "initial bank storage per meter of reach length"
-#define DESC_CHS0 "initial channel storage per meter of reach length"
-#define DESC_VSEEP0  "the initial volume of transmission loss to the deep aquifer over the time interval"
-#define DESC_A_BNK "bank flow recession constant"
-#define DESC_B_BNK "bank storage loss coefficient"
-#define DESC_MSK_X "muskingum weighing factor"
-#define DESC_MSK_CO1 "Weighting factor of bankful flow"
-#define DESC_VDIV "diversion loss of the river reach"
-#define DESC_VPOINT "point source discharge"
-#define DESC_MSF "flow velocity scaling factor for calibration"
-#define DESC_VSF "flow velocity scaling factor for calibration"
-#define DESC_SBOF "overland flow to streams from each subbasin"
-#define DESC_SBIF "interflow to streams from each subbasin"
-#define DESC_SBQG "groundwater flow out of the subbasin"
-#define DESC_SBPET "the potential evapotranspiration rate of the subbasin"
-#define DESC_SBGS "Groundwater storage of the subbasin"
-#define DESC_QRECH "Discharge in a text format at each reach outlet and at each time step"
-#define DESC_QOUTLET "discharge at the watershed outlet"
-#define DESC_QSOUTLET "discharge at the watershed outlet"
-#define DESC_QS "Overland discharge at each reach outlet and at each time step"
-#define DESC_QI "Interflow at each reach outlet and at each time step"
-#define DESC_QG "Groundwater discharge at each reach outlet and at each time step"
-#define DESC_CHST "channel storage"
-#define DESC_BKST "bank storage"
-#define DESC_SEEPAGE "seepage"
-#define DESC_CHWTDEPTH "channel water depth"
-#define DESC_QUPREACH "Upreach"
-#define DESC_OL_IUH "IUH of each grid cell"
-#define DESC_SSRU "The subsurface runoff"
-#define DESC_C_WABA "Channel water balance in a text format for each reach and at each time step"
-
-
-//////////////////////////////////////////////////////////////////////////
-/// Define unit names common used in SEIMS, in case of inconsistency /////
-/// By LiangJun Zhu, Apr. 25, 2016  //////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////
-#define VAR_ACC "acc"
 #define VAR_CDN "cdn"                               /// rate coefficient for denitrification
-#define VAR_CHWIDTH "CHWIDTH"
 #define VAR_CH_DEP "DEP"
 #define VAR_CH_DET "DET"
+#define VAR_CH_DETCO "ChDetCo"
 #define VAR_CH_FLOWCAP "CAP"
 #define VAR_CH_SEDRATE "QSN"
-#define VAR_CH_VOL "CHANVOL"
+#define VAR_CH_TCCO "ChTcCo"
 #define VAR_CH_V "CHANV"
+#define VAR_CH_VOL "CHANVOL"
+#define VAR_CHS0 "Chs0"                               /// initial channel storage per meter of reach length
+#define VAR_CHST "CHST"                               /// channel storage
+#define VAR_CHWIDTH "CHWIDTH"
+#define VAR_CHWTDEPTH "CHWTDEPTH"                               /// channel water depth
+#define VAR_CMN "cmn"                               /// Rate coefficient for mineralization of the humus active organic nutrients
 #define VAR_CO2 "Co2"                               /// CO2 Concentration
 #define VAR_COND_MAX "Cond_max"                     /// "Maximum automata's conductance"
 #define VAR_COND_RATE "Cond_rate"                   /// Rate of decline in automata's conductance per unit increase in vapor pressure deficit
-#define VAR_CMN "cmn"                               /// Rate coefficient for mineralization of the humus active organic nutrients
-#define VAR_CH_DETCO "ChDetCo"
-#define VAR_CH_TCCO "ChTcCo"					/// Calibration coefficient of transport capacity calculation
+#define VAR_DEET "DEET"                                  /// Distribution of evaporation from depression storage
+#define VAR_DEET "DEET"                                  /// evaporation from the depression storage
 #define VAR_DEM "DEM"                               /// Digital Elevation Model
+#define VAR_DEPREIN "Depre_in"                           /// initial depression storage coefficient
+#define VAR_DEPRESSION "Depression"                      /// Depression storage capacity
+#define VAR_DF_COEF "df_coef"                            /// Deep percolation coefficient
+#define VAR_DPST "DPST"                                  /// Distribution of depression storage
+#define VAR_DRYDEP_NH4 "drydep_nh4"                 /// atmospheric dry deposition of ammonia (kg/km2)
+#define VAR_DRYDEP_NO3 "drydep_no3"                 /// atmospheric dry deposition of nitrates (kg/km2)
+#define VAR_EP_CH "Ep_ch"                               /// reach evaporation adjustment factor
+#define VAR_EXCP "EXCP"                                  /// excess precipitation calculated in the infiltration module
+#define VAR_GW0 "GW0"                                    /// initial ground water storage
+#define VAR_GWMAX "GWMAX"                                /// maximum ground water storage
+#define VAR_GWNEW "GWNEW"                                /// The volume of water from the bank storage to the adjacent unsaturated zone and groundwater storage
+#define VAR_GWWB "GWWB"                                  /// 
 #define VAR_HCH "HCH"
+#define VAR_HMNTL "hmntl"                           /// amount of nitrogen moving from active organic to nitrate pool in soil profile on current day in cell(kg N/km2)
+#define VAR_HMPTL "hmptl"                           /// amount of phosphorus moving from the organic to labile pool in soil profile on current day in cell(kg P/km2)
+#define VAR_INET "INET"                                  /// evaporation from the interception storage obtained from the interception module
+#define VAR_INFIL "INFIL"                                /// Infiltration calculated in the infiltration module
 #define VAR_JULIAN_DAY "JDay"                       /// Julian day (int)
+#define VAR_K_BANK "K_bank"                              /// hydraulic conductivity of the channel bank
+#define VAR_K_CHB "K_chb"                                /// hydraulic conductivity of the channel bed
+#define VAR_KG "Kg"                                      /// Baseflow recession coefficient
 #define VAR_LAP_RATE "LapseRate"                    /// Lapse rate
+#define VAR_LCC "idplt"                             /// land cover code
 #define VAR_MANNING "Manning"
+#define VAR_MSF "ManningScaleFactor"                               /// flow velocity scaling factor for calibration
+#define VAR_MSK_CO1 "MSK_co1"                               /// Weighting factor of bankful flow
+#define VAR_MSK_X "MSK_X"                               /// muskingum weighing factor
+#define VAR_NACTFR "nactfr"                         /// nitrogen active pool fraction. The fraction of organic nitrogen in the active pool.
+#define VAR_OL_DET "DETOverland"
+#define VAR_OL_IUH "Ol_iuh"                               /// IUH of each grid cell
 #define VAR_OL_SED_CCOE "ccoe"
 #define VAR_OL_SED_ECO1 "eco1"
 #define VAR_OL_SED_ECO2 "eco2"
-#define VAR_OL_DET "DETOverland"
 #define VAR_OMP_THREADNUM "ThreadNum"               /// Thread numbers for OMP
+#define VAR_PERCO "Percolation"                          /// the amount of water percolated from the soil water reservoir
+#define VAR_PET "PET"                                    /// PET calculated from the spatial interpolation module
 #define VAR_PET_HCOEF "HCoef_pet"                   /// Coefficient related to radiation used in Hargreaves method
 #define VAR_PET_K "K_pet"                           /// Correction factor for PET
 #define VAR_PET_T "T_PET"                           /// Potential Evapotranspiration of day
 #define VAR_PL_RSDCO "rsdco_pl"                     /// Plant residue decomposition coefficient
-#define VAR_QRECH "QRECH"
-#define VAR_VP_SAT "svp"                            /// Saturated vapor pressure
-#define VAR_VP_ACT "avp"                            /// actual vapor pressure
+#define VAR_PRECI "D_P"                             /// precipitation for the day (mm)
+#define VAR_PSP "psp"                               /// Phosphorus availability index
+#define VAR_QG "QG"                               /// Groundwater discharge at each reach outlet and at each time step
+#define VAR_QI "QI"                               /// Interflow at each reach outlet and at each time step
+#define VAR_QOUTLET "QOUTLET"                               /// discharge at the watershed outlet
+#define VAR_QRECH "QRECH"                               /// Discharge in a text format at each reach outlet and at each time step
+#define VAR_QS "QS"                               /// Overland discharge at each reach outlet and at each time step
+#define VAR_QSOUTLET "QSOUTLET"                               /// discharge at the watershed outlet
+#define VAR_QUPREACH "QUPREACH"                               /// upreach
+#define VAR_RCA "rca"                               /// concentration of ammonia in the rain (mg N/m3)  L -> 0.001 * m3
+#define VAR_RCN "rcn"                               /// concentration of nitrate in the rain (mg N/m3)  L -> 0.001 * m3
+#define VAR_REVAP "Revap"                                /// 
+#define VAR_RG "RG"                                      /// 
+#define VAR_RMN2TL "rmn2tl"                         /// amount of nitrogen moving from the fresh organic (residue) to the nitrate(80%) and active organic(20%) pools in soil profile on current day in cell(kg N/km2)
+#define VAR_RMP1TL "rmp1tl"                         /// amount of phosphorus moving from the labile mineral pool to the active mineral pool in the soil profile on the current day in cell
+#define VAR_RMPTL "rmptl"                           /// amount of phosphorus moving from the fresh organic (residue) to the labile(80%) and organic(20%) pools in soil profile on current day in cell(kg P/km2)
+#define VAR_ROCTL "roctl"                           /// amount of phosphorus moving from the active mineral pool to the stable mineral pool in the soil profile on the current day in cell
+#define VAR_ROOTDEPTH "sol_z"                       /// depth to bottom of soil layer
+#define VAR_RWNTL "rwntl"                           /// amount of nitrogen moving from active organic to stable organic pool in soil profile on current day in cell(kg N/km2)
+#define VAR_SBGS "SBGS"                                  /// 
+#define VAR_SBGS "SBGS"                               /// Groundwater storage of the subbasin
+#define VAR_SBIF "SBIF"                               /// interflow to streams from each subbasin
+#define VAR_SBOF "SBOF"                               /// overland flow to streams from each subbasin
+#define VAR_SBPET "SBPET"                                /// 
+#define VAR_SBPET "SBPET"                               /// the potential evapotranspiration rate of the subbasin
+#define VAR_SBQG "SBQG"                                  /// 
+#define VAR_SBQG "SBQG"                               /// groundwater flow out of the subbasin
+#define VAR_SED_DEP "SEDDEP"
+#define VAR_SED_OUTLET "SEDOUTLET"
 #define VAR_SED_TO_CH "SEDTOCH"
 #define VAR_SED_TO_CH_T "SEDTOCH_T"
+#define VAR_SEDMINPA "sedminpa"                     /// amount of active mineral phosphorus adsorbed to sediment in surface runoff
+#define VAR_SEDMINPS "sedminps"                     /// amount of stable mineral phosphorus adsorbed to sediment in surface runoff
+#define VAR_SEDORGN "sedorgn"
+#define VAR_SEDORGP "sedorgp"                       /// amount of organic phosphorus in surface runoff
+#define VAR_SEEPAGE "SEEPAGE"                               /// seepage
 #define VAR_SLOPE "slope"
 #define VAR_SNAC "D_SNAC"
 #define VAR_SNOW_TEMP "T_snow"                      /// Snowfall temperature
-#define VAR_SR_MAX "srMax"                          /// Max solar radiation
-#define VAR_STREAM_LINK "STREAM_LINK"
-#define VAR_USLE_C "USLE_C"
-#define VAR_USLE_LS "USLE_LS"
-#define VAR_USLE_K "USLE_K"
-#define VAR_USLE_P "USLE_P"
-#define VAR_WSHD_DNIT "wshd_dnit"                   /// average annual amount of nitrogen lost from nitrate pool due to denitrification in watershed(kg N/km2)
-#define VAR_WSHD_HMN "wshd_hmn"                     /// average annual amount of nitrogen moving from active organic to nitrate pool in watershed(kg N/km2)
-#define VAR_WSHD_HMP "wshd_hmp"                     /// average annual amount of phosphorus moving from organic to labile pool in watershed(kg P/km2)
-#define VAR_WSHD_RMN "wshd_rmn"                     /// average annual amount of nitrogen moving from fresh organic (residue) to nitrate and active organic pools in watershed(kg N/km2)
-#define VAR_WSHD_RMP "wshd_rmp"                     /// average annual amount of phosphorus moving from fresh organic (residue) to labile and organic pools in watershed(kg P/km2)
-#define VAR_WSHD_RWN "wshd_rwn"                     /// average annual amount of nitrogen moving from active organic to stable organic pool in watershed(kg N/km2)
-#define VAR_WSHD_NITN "wshd_nitn"                   /// average annual amount of nitrogen moving from the NH3 to the NO3 pool by nitrification in the watershed
-#define VAR_WSHD_VOLN "wshd_voln"                   /// average annual amount if nitrogen lost by ammonia volatilization in watershed
-#define VAR_WSHD_PAL "wshd_pal"                     /// average annual amount of phosphorus moving from labile mineral to active mineral pool in watershed
-#define VAR_WSHD_PAS "wshd_pas"                     /// average annual amount of phosphorus moving from active mineral to stable mineral pool in watershed
-#define VAR_WSHD_RNO3 "wshd_rno3"                   /// average annual amount of NO3 added to soil by rainfall in watershed (kg/km2)
-#define VAR_LCC "idplt"                             /// land cover code
-#define VAR_NACTFR "nactfr"                         /// nitrogen active pool fraction. The fraction of organic nitrogen in the active pool.
-#define VAR_SOL_CBN "sol_cbn"                       /// percent organic carbon in soil layer(%)
-#define VAR_SOL_WST "sol_st"                        /// amount of water stored in the soil layer on current day(mm H2O)
-#define VAR_SOL_WFC "sol_fc"                        /// Water content of soil profile at field capacity(mm H2O)
-#define VAR_SOL_TMP "sol_tmp"                       /// daily average temperature of soil layer(deg C)
-#define VAR_SOL_WH "sol_ul"                         /// amount of water held in the soil layer at saturation(mm H2O)
+#define VAR_SOER "SOER"                             /// soil loss caused by water erosion (t)
+#define VAR_SOET "SOET"                                  /// evaporation from the soil water storage
+#define VAR_SOL_ACTP "sol_actp"                     /// amount of phosphorus stored in the active mineral phosphorus pool(kg P/km2)
 #define VAR_SOL_AORGN "sol_aorgn"                   /// amount of nitrogen stored in the active organic (humic) nitrogen pool(kg N/km2)
+#define VAR_SOL_BD "density"                        /// bulk density of the soil (mg/m3)
+#define VAR_SOL_CBN "sol_cbn"                       /// percent organic carbon in soil layer(%)
 #define VAR_SOL_FON "sol_fon"                       /// amount of nitrogen stored in the fresh organic (residue) pool(kg N/km2)
 #define VAR_SOL_FOP "sol_fop"                       /// amount of phosphorus stored in the fresh organic (residue) pool(kg P/km2)
+#define VAR_SOL_MP "sol_mp" 
+#define VAR_SOL_NH3 "sol_nh3"                       /// amount of nitrogen stored in the ammonium pool in soil layer
 #define VAR_SOL_NO3 "sol_no3"                       /// amount of nitrogen stored in the nitrate pool in soil layer(kg N/km2)
 #define VAR_SOL_ORGN "sol_orgn"                     /// amount of nitrogen stored in the stable organic N pool(kg N/km2)
 #define VAR_SOL_ORGP "sol_orgp"                     /// amount of phosphorus stored in the organic P pool in soil layer(kg P/km2)
 #define VAR_SOL_RSD "sol_rsd"                       /// amount of organic matter in the soil classified as residue(kg/km2)
 #define VAR_SOL_SOLP "sol_solp"                     /// amount of phosphorus stored in solution(kg P/km2)
-#define VAR_SOL_ACTP "sol_actp"                     /// amount of phosphorus stored in the active mineral phosphorus pool(kg P/km2)
 #define VAR_SOL_STAP "sol_stap"                     /// amount of phosphorus in the soil layer stored in the stable mineral phosphorus pool(kg P/km2)
-#define VAR_SOL_NH3 "sol_nh3"                       /// amount of nitrogen stored in the ammonium pool in soil layer
+#define VAR_SOL_TMP "sol_tmp"                       /// daily average temperature of soil layer(deg C)
+#define VAR_SOL_WFC "sol_fc"                        /// Water content of soil profile at field capacity(mm H2O)
+#define VAR_SOL_WH "sol_ul"                         /// amount of water held in the soil layer at saturation(mm H2O)
 #define VAR_SOL_WPMM "sol_wpmm"                     /// water content of soil at -1.5 MPa (wilting point)
-#define VAR_SOL_BD "density"                        /// bulk density of the soil (mg/m3)
-#define VAR_SOL_MP "sol_mp" 
-#define VAR_SOER "SOER"                             /// soil loss caused by water erosion (t)
+#define VAR_SOL_WST "sol_st"                        /// amount of water stored in the soil layer on current day(mm H2O)
+#define VAR_SOMO "SOMO"                                  /// Distribution of soil moisture
+#define VAR_SR_MAX "srMax"                          /// Max solar radiation
+#define VAR_SSRU "SSRU"                               /// The subsurface runoff
+#define VAR_STREAM_LINK "STREAM_LINK"
+#define VAR_SUBBSN "subbasin"                            /// The subbasin grid
 #define VAR_SURU "SURU"                           /// surface runoff generated
-#define VAR_HMNTL "hmntl"                           /// amount of nitrogen moving from active organic to nitrate pool in soil profile on current day in cell(kg N/km2)
-#define VAR_HMPTL "hmptl"                           /// amount of phosphorus moving from the organic to labile pool in soil profile on current day in cell(kg P/km2)
-#define VAR_RMN2TL "rmn2tl"                         /// amount of nitrogen moving from the fresh organic (residue) to the nitrate(80%) and active organic(20%) pools in soil profile on current day in cell(kg N/km2)
-#define VAR_RMPTL "rmptl"                           /// amount of phosphorus moving from the fresh organic (residue) to the labile(80%) and organic(20%) pools in soil profile on current day in cell(kg P/km2)
-#define VAR_RWNTL "rwntl"                           /// amount of nitrogen moving from active organic to stable organic pool in soil profile on current day in cell(kg N/km2)
-#define VAR_WDNTL "wdntl"                           /// amount of nitrogen lost from nitrate pool by denitrification in soil profile on current day in cell(kg N/km2)
-#define VAR_ROOTDEPTH "sol_z"                       /// depth to bottom of soil layer
-#define VAR_PSP "psp"                               /// Phosphorus availability index
-#define VAR_RMP1TL "rmp1tl"                         /// amount of phosphorus moving from the labile mineral pool to the active mineral pool in the soil profile on the current day in cell
-#define VAR_ROCTL "roctl"                           /// amount of phosphorus moving from the active mineral pool to the stable mineral pool in the soil profile on the current day in cell
 #define VAR_TSD_DT "data_type"                      /// Time series data type
-#define VAR_SED_DEP "SEDDEP"
-#define VAR_SED_OUTLET "SEDOUTLET"
-#define VAR_SEDORGN "sedorgn"						/// amount of organic nitrogen in surface runoff
-#define VAR_SEDORGP "sedorgp"                       /// amount of organic phosphorus in surface runoff
-#define VAR_SEDMINPA "sedminpa"                     /// amount of active mineral phosphorus adsorbed to sediment in surface runoff
-#define VAR_SEDMINPS "sedminps"                     /// amount of stable mineral phosphorus adsorbed to sediment in surface runoff
-#define VAR_ADDRNO3 "addrno3"                       /// nitrate added by rainfall (kg/km2)
-#define VAR_ADDRNH3 "addrnh3"                       /// ammonium added by rainfall (kg/km2)
-#define VAR_DRYDEP_NO3 "drydep_no3"                 /// atmospheric dry deposition of nitrates (kg/km2)
-#define VAR_DRYDEP_NH4 "drydep_nh4"                 /// atmospheric dry deposition of ammonia (kg/km2)
-#define VAR_PRECI "D_P"                             /// precipitation for the day (mm)
-#define VAR_RCN "rcn"                               /// concentration of nitrate in the rain (mg N/m3)  L -> 0.001 * m3
-#define VAR_RCA "rca"                               /// concentration of ammonia in the rain (mg N/m3)  L -> 0.001 * m3
-
+#define VAR_USLE_C "USLE_C"
+#define VAR_USLE_K "USLE_K"
+#define VAR_USLE_LS "USLE_LS"
+#define VAR_USLE_P "USLE_P"
+#define VAR_VDIV "Vdiv"                               /// diversion loss of the river reach
+#define VAR_VP_ACT "avp"                            /// actual vapor pressure
+#define VAR_VP_SAT "svp"                            /// Saturated vapor pressure
+#define VAR_VPOINT "Vpoint"                               /// point source discharge
+#define VAR_VSEEP0 "Vseep0"                               ///  the initial volume of transmission loss to the deep aquifer over the time interval
+#define VAR_VSF "VelScaleFactor"                               /// flow velocity scaling factor for calibration
+#define VAR_WDNTL "wdntl"                           /// amount of nitrogen lost from nitrate pool by denitrification in soil profile on current day in cell(kg N/km2)
+#define VAR_WSHD_DNIT "wshd_dnit"                   /// average annual amount of nitrogen lost from nitrate pool due to denitrification in watershed(kg N/km2)
+#define VAR_WSHD_HMN "wshd_hmn"                     /// average annual amount of nitrogen moving from active organic to nitrate pool in watershed(kg N/km2)
+#define VAR_WSHD_HMP "wshd_hmp"                     /// average annual amount of phosphorus moving from organic to labile pool in watershed(kg P/km2)
+#define VAR_WSHD_NITN "wshd_nitn"                   /// average annual amount of nitrogen moving from the NH3 to the NO3 pool by nitrification in the watershed
+#define VAR_WSHD_PAL "wshd_pal"                     /// average annual amount of phosphorus moving from labile mineral to active mineral pool in watershed
+#define VAR_WSHD_PAS "wshd_pas"                     /// average annual amount of phosphorus moving from active mineral to stable mineral pool in watershed
+#define VAR_WSHD_RMN "wshd_rmn"                     /// average annual amount of nitrogen moving from fresh organic (residue) to nitrate and active organic pools in watershed(kg N/km2)
+#define VAR_WSHD_RMP "wshd_rmp"                     /// average annual amount of phosphorus moving from fresh organic (residue) to labile and organic pools in watershed(kg P/km2)
+#define VAR_WSHD_RNO3 "wshd_rno3"                   /// average annual amount of NO3 added to soil by rainfall in watershed (kg/km2)
+#define VAR_WSHD_RWN "wshd_rwn"                     /// average annual amount of nitrogen moving from active organic to stable organic pool in watershed(kg N/km2)
+#define VAR_WSHD_VOLN "wshd_voln"                   /// average annual amount if nitrogen lost by ammonia volatilization in watershed
 
 //////////////////////////////////////////////////////////////////////////
 /// Define units common used in SEIMS, in case of inconsistency //////////
-/// By LiangJun Zhu, Apr. 25, 2016  //////////////////////////////////////
+/// By LiangJun Zhu, HuiRan Gao ///
+/// Apr. , 2016  //////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
 
 #define UNIT_AREA_KM2 "km2"                         /// Square kilometer of area
 #define UNIT_CONDRATE_MSPA "m/s/kPa"                /// Rate of decline in stomatal conductance per unit increase in vapor pressure deficit
 #define UNIT_CONT_KGKM2 "kg/km2"                    /// Kilograms per Square kilometers of nutrient content
-#define UNIT_KGM3 "kg/m3"
+#define UNIT_DENSITY "mg/m3"                        /// density
 #define UNIT_DEPTH_MM "mm"                          /// Depth related unit, mm
-#define UNIT_VOL_CM "m3"
 #define UNIT_FLOW_CMS "m3/s"                        /// Cubic meters per second of flow discharge
 #define UNIT_GAS_PPMV "ppmv"                        /// Concentration of gas, e.g., CO2
+#define UNIT_KG "kg"                                /// mass Kg
+#define UNIT_KG_S "kg/s"
+#define UNIT_KGM3 "kg/m3"
 #define UNIT_LAP_RATE "/100m"                       /// Lapse rate
 #define UNIT_LEN_M "m"                              /// Meter of length
 #define UNIT_LONLAT_DEG "degree"                    /// Degree of longitude and latitude
 #define UNIT_NON_DIM ""                             /// Non dimension  
+#define UNIT_PERCENT "%"                            /// Percent
 #define UNIT_PRESSURE "kPa"                         /// Vapor pressure
+#define UNIT_SECOND
 #define UNIT_SPEED_MS "m/s"                         /// Speed related
 #define UNIT_SR "MJ/m2/d"                           /// Solar Radiation
+#define UNIT_STRG_M3M "m3/m"                       /// storage per meter of reach length
 #define UNIT_TEMP_DEG "deg C"                       /// Celsius degree of air temperature 
-#define UNIT_WTRDLT_MMD "mm/d"                      /// Millimeter per day of water changes
-#define UNIT_WTRDLT_MMH "mm/h"                      /// Millimeter per hour of water changes
-#define UNIT_PERCENT "%"                            /// Percent
-#define UNIT_TONS "t"                               /// metric tons
-#define UNIT_KG_S "kg/s"
-#define UNIT_DENSITY "mg/m3"                        /// density
-#define UNIT_SECOND	"second"
-#define UNIT_KG "kg"                                /// mass Kg
 #define UNIT_TIMESTEP_HOUR "hr"                     /// Time step (h)
 #define UNIT_TIMESTEP_SEC "s"                      /// Time step (s)
+#define UNIT_TONS "t"                               /// metric tons
+#define UNIT_VOL_CM "m3"
 #define UNIT_VOL_M3 "m3"                           /// volume
-#define UNIT_STRG_M3M "m3/m"                       /// storage per meter of reach length
+#define UNIT_WTRDLT_MMD "mm/d"                      /// Millimeter per day of water changes
+#define UNIT_WTRDLT_MMH "mm/h"                      /// Millimeter per hour of water changes
+
 
 //////////////////////////////////////////////////////////////////////////
 /// Define description of units common used in SEIMS            //////////
-/// By LiangJun Zhu, Apr. 25, 2016  //////////////////////////////////////
+/// By LiangJun Zhu, HuiRan Gao //////////////////////////
+///               Apr. 25, 2016  //////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
+#define DESC_A_BNK "bank flow recession constant"
 #define DESC_ACC "the number of flow accumulation cells of each cell"
-#define DESC_CH_DETCO "Calibration coefficient of channel flow detachment"
+#define DESC_ADDRNH3 "ammonium added by rainfall"
+#define DESC_ADDRNO3 "nitrate added by rainfall"
+#define DESC_B_BNK "bank storage loss coefficient"
+#define DESC_BASE_EX "baseflow recession exponent"
+#define DESC_BKST "bank storage"
+#define DESC_BNK0 "initial bank storage per meter of reach length"
+#define DESC_C_WABA "Channel water balance in a text format for each reach and at each time step"
+#define DESC_CDN "rate coefficient for denitrification"
+#define DESC_CellSize "numble of valid cells, i.e., excluding NODATA"
+#define DESC_CellWidth "width of the cell"
 #define DESC_CH_DEP "distribution of channel sediment deposition"
 #define DESC_CH_DET "distribution of channel flow detachment"
+#define DESC_CH_DETCO "Calibration coefficient of channel flow detachment"
 #define DESC_CH_FLOWCAP "distribution of channel flow capacity"
 #define DESC_CH_SEDRATE "distribution of channel sediment rate"
 #define DESC_CH_TCCO "Calibration coefficient of transport capacity calculation"
-#define DESC_CH_VOL "water volume"
 #define DESC_CH_V "flow velocity"
+#define DESC_CH_VOL "water volume"
+#define DESC_CHS0 "initial channel storage per meter of reach length"
+#define DESC_CHST "channel storage"
 #define DESC_CHWIDTH "Channel width"
+#define DESC_CHWTDEPTH "channel water depth"
+#define DESC_CMN "Rate coefficient for mineralization of the humus active organic nutrients"
 #define DESC_CO2 "CO2 Concentration"
 #define DESC_CONDRATE "Rate of decline in stomatal conductance per unit increase in vapor pressure deficit"
+#define DESC_DEET "Distribution of evaporation from depression storage"
 #define DESC_DEM "Digital Elevation Model"
+#define DESC_DEPREIN "initial depression storage coefficient"
+#define DESC_DEPRESSION "Depression storage capacity"
+#define DESC_DF_COEF "Deep percolation coefficient"
+#define DESC_DPST "Distribution of depression storage"
+#define DESC_DRYDEP_NH4 "atmospheric dry deposition of ammonia"
+#define DESC_DRYDEP_NO3 "tmospheric dry deposition of nitrates"
 #define DESC_DT_HS "Time step of the simulation"
+#define DESC_EP_CH "reach evaporation adjustment factor"
+#define DESC_EXCP "excess precipitation calculated in the infiltration module"
 #define DESC_FLOWIN_INDEX "The index of flow in (D8) cell in the compressed array, and the first element in each sub-array is the number of flow in cells in this sub-array"
 #define DESC_FLOWOUT_INDEX "The index of flow out (D8) cell of each cells in the compressed array"
+#define DESC_GW0 "initial ground water storage"
+#define DESC_GWMAX "maximum ground water storage"
+#define DESC_GWNEW "The volume of water from the bank storage to the adjacent unsaturated zone and groundwater storage"
 #define DESC_HCH "Water depth in the downslope boundary of cells"
+#define DESC_HMNTL "amount of nitrogen moving from active organic to nitrate pool in soil profile on current day in cell"
+#define DESC_HMPTL "amount of phosphorus moving from the organic to labile pool in soil profile on current day in cell"
+#define DESC_INET "evaporation from the interception storage obtained from the interception module"
+#define DESC_INFIL "Infiltration calculated in the infiltration module"
 #define DESC_JULIAN_DAY "Julian day (int)"
+#define DESC_K_BANK "hydraulic conductivity of the channel bank"
+#define DESC_K_CHB "hydraulic conductivity of the channel bed"
+#define DESC_KG "Baseflow recession coefficient"
 #define DESC_LAP_RATE "Lapse Rate"
+#define DESC_LCC "land cover code"
 #define DESC_MANNING "Manning's roughness"
 #define DESC_MAXCOND "Maximum stomatal conductance"
 #define DESC_MAXTEMP "Maximum Celsius degree of air temperature"
 #define DESC_MEANTEMP "Mean Celsius degree of air temperature"
 #define DESC_METEOLAT "Latitude of MeteoClimate station"
 #define DESC_MINTEMP "Minimum Celsius degree of air temperature"
+#define DESC_MSF "flow velocity scaling factor for calibration"
+#define DESC_MSK_CO1 "Weighting factor of bankful flow"
+#define DESC_MSK_X "muskingum weighing factor"
+#define DESC_NACTFR "nitrogen active pool fraction. The fraction of organic nitrogen in the active pool."
 #define DESC_NONE ""
 #define DESC_OL_DET "distribution of overland flow detachment"
+#define DESC_OL_IUH "IUH of each grid cell"
+#define DESC_OL_SED_CCOE "calibration coefficient of overland flow detachment erosion"
 #define DESC_OL_SED_ECO1 "calibration coefficient of transport capacity calculation"
 #define DESC_OL_SED_ECO2 "calibration coefficient of transport capacity calculation"
-#define DESC_OL_SED_CCOE "calibration coefficient of overland flow detachment erosion"
+#define DESC_PERCO "the amount of water percolated from the soil water reservoir"
+#define DESC_PET "PET calculated from the spatial interpolation module"
 #define DESC_PET_HCOEF "Coefficient related to radiation used in Hargreaves method"
 #define DESC_PET_K "Correction factor for PET"
 #define DESC_PET_T "Potential Evapotranspiration of day"
 #define DESC_PL_RSDCO "Plant residue decomposition coefficient"
+#define DESC_PRECI "precipitation for the day"
+#define DESC_PSP "Phosphorus availability index"
+#define DESC_QG "Groundwater discharge at each reach outlet and at each time step"
+#define DESC_QI "Interflow at each reach outlet and at each time step"
+#define DESC_QOUTLET "discharge at the watershed outlet"
+#define DESC_QRECH "Discharge in a text format at each reach outlet and at each time step"
+#define DESC_QS "Overland discharge at each reach outlet and at each time step"
+#define DESC_QSOUTLET "discharge at the watershed outlet"
+#define DESC_QUPREACH "Upreach"
+#define DESC_RCA "concentration of ammonia in the rain"
+#define DESC_RCN "concentration of nitrate in the rain"
 #define DESC_RM "Relative humidity"
+#define DESC_RMN2TL "amount of nitrogen moving from the fresh organic (residue) to the nitrate(80%) and active organic(20%) pools in soil profile on current day in cell"
+#define DESC_RMP1TL "amount of phosphorus moving from the labile mineral pool to the active mineral pool in the soil profile on the current day in cell"
+#define DESC_RMPTL "amount of phosphorus moving from the fresh organic (residue) to the labile(80%) and organic(20%) pools in soil profile on current day in cell"
+#define DESC_ROCTL "amount of phosphorus moving from the active mineral pool to the stable mineral pool in the soil profile on the current day in cell"
+#define DESC_ROOTDEPTH "depth to bottom of soil layer"
 #define DESC_ROUTING_LAYERS "Routing layers according to the flow direction, there are no flow relationships within each layer, and the first element in each layer is the number of cells in the layer"
-#define DESC_QRECH "Flux in the downslope boundary of cells"
+#define DESC_RWNTL "amount of nitrogen moving from active organic to stable organic pool in soil profile on current day in cell"
+#define DESC_SBGS "Groundwater storage of the subbasin"
+#define DESC_SBIF "interflow to streams from each subbasin"
+#define DESC_SBOF "overland flow to streams from each subbasin"
+#define DESC_SBPET "the potential evapotranspiration rate of the subbasin"
+#define DESC_SBQG "groundwater flow out of the subbasin"
 #define DESC_SED_DEP "distribution of sediment deposition"
+#define DESC_SED_OUTLET "Sediment concentration at the watershed outlet"
 #define DESC_SED_TO_CH "Distribution of sediment flowing to channel"
 #define DESC_SED_TO_CH_T  "Total sediment flowing to channel"
-#define DESC_SED_OUTLET "Sediment concentration at the watershed outlet"
+#define DESC_SEDMINPA " amount of active mineral phosphorus sorbed to sediment in surface runoff"
+#define DESC_SEDMINPS "amount of stable mineral phosphorus sorbed to sediment in surface runoff"
+#define DESC_SEDORGN "amount of organic nitrogen in surface runoff"
+#define DESC_SEDORGP "amount of organic phosphorus in surface runoff"
+#define DESC_SEEPAGE "seepage"
 #define DESC_SLOPE "Slope gradient (percentage)"
 #define DESC_SNAC "snow accumulation"
-#define DESC_STREAM_LINK "Stream link (id of reaches)"
-#define DESC_USLE_C "the cover management factor"
-#define DESC_USLE_K "The soil erodibility factor used in USLE"
-#define DESC_USLE_P "the erosion control practice factor "
-#define DESC_USLE_LS "USLE LS factor"
-#define DESC_CDN "rate coefficient for denitrification"
-#define DESC_CMN "Rate coefficient for mineralization of the humus active organic nutrients"
 #define DESC_SNOW_TEMP "Snowfall temperature"
-#define DESC_SR "Solar radiation"
-#define DESC_SR_MAX "Max solar radiation"
-#define DESC_TSD_DT "Time series data type, e.g., climate data"
-#define DESC_TSD_CLIMATE "Climate data of all the stations"
-#define DESC_VER_ITP "Execute vertical interpolation (1) or not (0), defined in config.fig"
-#define DESC_VP_SAT "Saturated vapor pressure"
-#define DESC_VP_ACT "actual vapor pressure"
-#define DESC_WEIGHT_ITP "Weight used for interpolation"
-#define DESC_WS "Wind speed (measured at 10 meters above surface)"
-#define DESC_WSHD_DNIT "average annual amount of nitrogen lost from nitrate pool due to denitrification in watershed"
-#define DESC_WSHD_HMN "average annual amount of nitrogen moving from active organic to nitrate pool in watershed"
-#define DESC_WSHD_HMP "average annual amount of phosphorus moving from organic to labile pool in watershed"
-#define DESC_WSHD_RMN "average annual amount of nitrogen moving from fresh organic (residue) to nitrate and active organic pools in watershed"
-#define DESC_WSHD_RMP "average annual amount of phosphorus moving from fresh organic (residue) to labile and organic pools in watershed"
-#define DESC_WSHD_RWN "average annual amount of nitrogen moving from active organic to stable organic pool in watershed" 
-#define DESC_WSHD_NITN "average annual amount of nitrogen moving from the NH3 to the NO3 pool by nitrification in the watershed"
-#define DESC_WSHD_VOLN "average annual amount if nitrogen lost by ammonia volatilization in watershed" 
-#define DESC_WSHD_PAL "average annual amount of phosphorus moving from labile mineral to active mineral pool in watershed"
-#define DESC_WSHD_PAS "average annual amount of phosphorus moving from active mineral to stable mineral pool in watershed"
-#define DESC_WSHD_RNO3 "average annual amount of NO3 added to soil by rainfall in watershed"
-#define DESC_LCC "land cover code"
-#define DESC_NACTFR "nitrogen active pool fraction. The fraction of organic nitrogen in the active pool."
 #define DESC_SOER "soil loss caused by water erosion"
-#define DESC_SURU "surface runoff generated"
-#define DESC_SOL_CBN "percent organic carbon in soil layer"
-#define DESC_SOL_WST "amount of water stored in the soil layer on current day"
-#define DESC_SOL_WFC "Water content of soil profile at field capacity"
-#define DESC_SOL_TMP "daily average temperature of soil layer"
-#define DESC_SOL_WH "amount of water held in the soil layer at saturation"
+#define DESC_SOET "evaporation from the soil water storage"
+#define DESC_SOL_ACTP "amount of phosphorus stored in the active mineral phosphorus pool"
 #define DESC_SOL_AORGN "amount of nitrogen stored in the active organic (humic) nitrogen pool"
+#define DESC_SOL_BD "bulk density of the soil"
+#define DESC_SOL_CBN "percent organic carbon in soil layer"
 #define DESC_SOL_FON "amount of nitrogen stored in the fresh organic (residue) pool"
 #define DESC_SOL_FOP "amount of phosphorus stored in the fresh organic (residue) pool"
+#define DESC_SOL_MP "??"
+#define DESC_SOL_NH3 "amount of nitrogen stored in the ammonium pool in soil layer"
 #define DESC_SOL_NO3 "amount of nitrogen stored in the nitrate pool in soil layer"
 #define DESC_SOL_ORGN "amount of nitrogen stored in the stable organic N pool"
 #define DESC_SOL_ORGP "amount of phosphorus stored in the organic P pool in soil layer"
 #define DESC_SOL_RSD "amount of organic matter in the soil classified as residue"
 #define DESC_SOL_SOLP "amount of phosohorus stored in solution"
-#define DESC_SOL_NH3 "amount of nitrogen stored in the ammonium pool in soil layer"
-#define DESC_SOL_WPMM " water content of soil at -1.5 MPa (wilting point)"
-#define DESC_SOL_ACTP "amount of phosphorus stored in the active mineral phosphorus pool"
 #define DESC_SOL_STAP "amount of phosphorus in the soil layer stored in the stable mineral phosphorus pool"
-#define DESC_SOL_BD "bulk density of the soil"
-#define DESC_SOL_MP "??"
-#define DESC_HMNTL "amount of nitrogen moving from active organic to nitrate pool in soil profile on current day in cell"
-#define DESC_HMPTL "amount of phosphorus moving from the organic to labile pool in soil profile on current day in cell"
-#define DESC_RMN2TL "amount of nitrogen moving from the fresh organic (residue) to the nitrate(80%) and active organic(20%) pools in soil profile on current day in cell"
-#define DESC_RMPTL "amount of phosphorus moving from the fresh organic (residue) to the labile(80%) and organic(20%) pools in soil profile on current day in cell"
-#define DESC_RWNTL "amount of nitrogen moving from active organic to stable organic pool in soil profile on current day in cell"
+#define DESC_SOL_TMP "daily average temperature of soil layer"
+#define DESC_SOL_WFC "Water content of soil profile at field capacity"
+#define DESC_SOL_WH "amount of water held in the soil layer at saturation"
+#define DESC_SOL_WPMM " water content of soil at -1.5 MPa (wilting point)"
+#define DESC_SOL_WST "amount of water stored in the soil layer on current day"
+#define DESC_SOMO "Distribution of soil moisture"
+#define DESC_SR "Solar radiation"
+#define DESC_SR_MAX "Max solar radiation"
+#define DESC_SSRU "The subsurface runoff"
+#define DESC_STREAM_LINK "Stream link (id of reaches)"
+#define DESC_SUBBSN "The subbasion grid"
+#define DESC_SURU "surface runoff generated"
+#define DESC_TIMESTEP "time step"
+#define DESC_TSD_CLIMATE "Climate data of all the stations"
+#define DESC_TSD_DT "Time series data type, e.g., climate data"
+#define DESC_USLE_C "the cover management factor"
+#define DESC_USLE_K "The soil erodibility factor used in USLE"
+#define DESC_USLE_LS "USLE LS factor"
+#define DESC_USLE_P "the erosion control practice factor "
+#define DESC_VDIV "diversion loss of the river reach"
+#define DESC_VER_ITP "Execute vertical interpolation (1) or not (0), defined in config.fig"
+#define DESC_VP_ACT "actual vapor pressure"
+#define DESC_VP_SAT "Saturated vapor pressure"
+#define DESC_VPOINT "point source discharge"
+#define DESC_VSEEP0  "the initial volume of transmission loss to the deep aquifer over the time interval"
+#define DESC_VSF "flow velocity scaling factor for calibration"
 #define DESC_WDNTL "amount of nitrogen lost from nitrate pool by denitrification in soil profile on current day in cell"
-#define DESC_ROOTDEPTH "depth to bottom of soil layer"
-#define DESC_PSP "Phosphorus availability index"
-#define DESC_RMP1TL "amount of phosphorus moving from the labile mineral pool to the active mineral pool in the soil profile on the current day in cell"
-#define DESC_ROCTL "amount of phosphorus moving from the active mineral pool to the stable mineral pool in the soil profile on the current day in cell"
-#define DESC_CellSize "numble of valid cells, i.e., excluding NODATA"
-#define DESC_CellWidth "width of the cell"
-#define DESC_SEDORGN "amount of organic nitrogen in surface runoff"
-#define DESC_SEDORGP "amount of organic phosphorus in surface runoff"
-#define DESC_SEDMINPA " amount of active mineral phosphorus sorbed to sediment in surface runoff"
-#define DESC_SEDMINPS "amount of stable mineral phosphorus sorbed to sediment in surface runoff"
-#define DESC_ADDRNO3 "nitrate added by rainfall"
-#define DESC_ADDRNH3 "ammonium added by rainfall"
-#define DESC_DRYDEP_NO3 "tmospheric dry deposition of nitrates"
-#define DESC_DRYDEP_NH4 "atmospheric dry deposition of ammonia"
-#define DESC_PRECI "precipitation for the day"
-#define DESC_RCN "concentration of nitrate in the rain"
-#define DESC_RCA "concentration of ammonia in the rain"
+#define DESC_WEIGHT_ITP "Weight used for interpolation"
+#define DESC_WS "Wind speed (measured at 10 meters above surface)"
+#define DESC_WSHD_DNIT "average annual amount of nitrogen lost from nitrate pool due to denitrification in watershed"
+#define DESC_WSHD_HMN "average annual amount of nitrogen moving from active organic to nitrate pool in watershed"
+#define DESC_WSHD_HMP "average annual amount of phosphorus moving from organic to labile pool in watershed"
+#define DESC_WSHD_NITN "average annual amount of nitrogen moving from the NH3 to the NO3 pool by nitrification in the watershed"
+#define DESC_WSHD_PAL "average annual amount of phosphorus moving from labile mineral to active mineral pool in watershed"
+#define DESC_WSHD_PAS "average annual amount of phosphorus moving from active mineral to stable mineral pool in watershed"
+#define DESC_WSHD_RMN "average annual amount of nitrogen moving from fresh organic (residue) to nitrate and active organic pools in watershed"
+#define DESC_WSHD_RMP "average annual amount of phosphorus moving from fresh organic (residue) to labile and organic pools in watershed"
+#define DESC_WSHD_RNO3 "average annual amount of NO3 added to soil by rainfall in watershed"
+#define DESC_WSHD_RWN "average annual amount of nitrogen moving from active organic to stable organic pool in watershed" 
+#define DESC_WSHD_VOLN "average annual amount if nitrogen lost by ammonia volatilization in watershed" 
+
 
 //////////////////////////////////////////////////////////////////////////
 /// Define MongoDB related constant strings used in SEIMS and preprocess//

--- a/src/modules/erosion/KinWavSed_CH/api.cpp
+++ b/src/modules/erosion/KinWavSed_CH/api.cpp
@@ -50,8 +50,8 @@ extern "C" SEIMS_MODULE_API const char* MetadataInformation()
 	// input from other module
 	mdi.AddInput(VAR_SED_TO_CH,UNIT_KG, DESC_SED_TO_CH, Source_Module,DT_Raster1D);
 	mdi.AddInput(VAR_HCH,UNIT_DEPTH_MM, DESC_HCH,Source_Module,DT_Array2D);
-	mdi.AddInput(VAR_QRECH, UNIT_FLOW_CMS, DESC_QRECH, Source_Module,DT_Array2D);
-	
+	//mdi.AddInput(VAR_QRECH, UNIT_FLOW_CMS, DESC_QRECH, Source_Module,DT_Array2D);
+	mdi.AddInput("QRECH", "m3/s", "Flux in the downslope boundary of cells", "Module",DT_Array2D);// from which module? By LJ
 	/// set the output variables
 	
 	mdi.AddOutput(VAR_SED_OUTLET, UNIT_KGM3, DESC_SED_OUTLET, DT_Single);

--- a/src/modules/hydrology_longterm/IKW_REACH/api.cpp
+++ b/src/modules/hydrology_longterm/IKW_REACH/api.cpp
@@ -32,7 +32,7 @@ extern "C" SEIMS_MODULE_API const char* MetadataInformation()
 
 	mdi.AddParameter(Tag_ChannelTimeStep, UNIT_TIMESTEP_SEC, DESC_TIMESTEP, File_Input,DT_Single); 
 	mdi.AddParameter(VAR_K_CHB,  UNIT_WTRDLT_MMH, DESC_K_CHB, Source_ParameterDB, DT_Single);
-	mdi.AddParameter(VAR_K_BANK, UNIT_WTRDLT_MMH, , Source_ParameterDB, DT_Single);
+	mdi.AddParameter(VAR_K_BANK, UNIT_WTRDLT_MMH,DESC_K_BANK , Source_ParameterDB, DT_Single);
 	mdi.AddParameter(VAR_EP_CH, UNIT_WTRDLT_MMH, DESC_EP_CH, Source_ParameterDB, DT_Single);
 	mdi.AddParameter(VAR_BNK0, UNIT_STRG_M3M, DESC_BNK0, Source_ParameterDB, DT_Single);
 	mdi.AddParameter(VAR_CHS0, UNIT_STRG_M3M, DESC_CHS0, Source_ParameterDB, DT_Single);
@@ -44,7 +44,7 @@ extern "C" SEIMS_MODULE_API const char* MetadataInformation()
 	mdi.AddParameter(VAR_QUPREACH, UNIT_NON_DIM, DESC_QUPREACH, Source_ParameterDB, DT_Single);
 	//mdi.AddParameter(VAR_MSF, UNIT_NON_DIM, DESC_MSF, Source_ParameterDB, DT_Single);
 
-	mdi.AddParameter(Tag_RchParam, UNIT_NON_DIM, "reach parameters", File_ReachPara, DT_Array2D);
+	mdi.AddParameter(Tag_RchParam, UNIT_NON_DIM, DESC_REACH_PARAMETER, Source_ParameterDB, DT_Array2D);
 	//mdi.AddParameter(VAR_VDIV, UNIT_VOL_M3, DESC_VDIV, DT_Array1D);
 	//mdi.AddParameter(VAR_VPOINT, UNIT_VOL_M3, DESC_VPOINT, "diversionloss.txt", DT_Array1D);
 	mdi.AddParameter(VAR_SUBBSN, UNIT_NON_DIM, DESC_SUBBSN, Source_ParameterDB, DT_Raster1D);
@@ -55,7 +55,7 @@ extern "C" SEIMS_MODULE_API const char* MetadataInformation()
 	mdi.AddInput(VAR_SBPET, UNIT_DEPTH_MM, DESC_SBPET, Source_Module, DT_Array1D);
 	mdi.AddInput(VAR_SBGS, UNIT_DEPTH_MM, DESC_SBGS, Source_Module, DT_Array1D);
 
-	mdi.AddOutput(VAR_QRECH, UNIT_NON_DIM, DESC_QRECH, DT_Array1D);
+	mdi.AddOutput(VAR_QRECH, UNIT_FLOW_CMS, DESC_QRECH, DT_Array1D);
 	mdi.AddOutput(VAR_QOUTLET,  UNIT_FLOW_CMS, DESC_QOUTLET, DT_Single);
 	mdi.AddOutput(VAR_QSOUTLET,  UNIT_FLOW_CMS, DESC_QSOUTLET, DT_Single);
 	mdi.AddOutput(VAR_QS, UNIT_NON_DIM, DESC_QS, DT_Array1D);

--- a/src/modules/hydrology_longterm/MUSK_CH/api.cpp
+++ b/src/modules/hydrology_longterm/MUSK_CH/api.cpp
@@ -60,7 +60,7 @@ extern "C" SEIMS_MODULE_API const char* MetadataInformation()
 
 	mdi.AddParameter(Tag_ChannelTimeStep, UNIT_TIMESTEP_SEC, DESC_TIMESTEP, File_Input,DT_Single); 
 	mdi.AddParameter(VAR_K_CHB,  UNIT_WTRDLT_MMH, DESC_K_CHB, Source_ParameterDB, DT_Single);
-	mdi.AddParameter(VAR_K_BANK, UNIT_WTRDLT_MMH, , Source_ParameterDB, DT_Single);
+	mdi.AddParameter(VAR_K_BANK, UNIT_WTRDLT_MMH,DESC_K_BANK , Source_ParameterDB, DT_Single);
 	mdi.AddParameter(VAR_EP_CH, UNIT_WTRDLT_MMH, DESC_EP_CH, Source_ParameterDB, DT_Single);
 	mdi.AddParameter(VAR_BNK0, UNIT_STRG_M3M, DESC_BNK0, Source_ParameterDB, DT_Single);
 	mdi.AddParameter(VAR_CHS0, UNIT_STRG_M3M, DESC_CHS0, Source_ParameterDB, DT_Single);


### PR DESCRIPTION
+ VAR_
+ UNIT_
+ DESC_

变量名、单位、描述的宏定义要按照字母表顺序排列，以便及时发现问题。
比如，某模块的AddInput参数与对应模块的AddOutput不一致，不一致包括变量描述、DimensionType等。

@gaohr 