### PR TITLE
目前预处理程序中对土壤理化性质的更新已完成

### DIFF
--- a/preprocess/DischargeDaily.py
+++ b/preprocess/DischargeDaily.py
@@ -52,3 +52,11 @@ def ImportDailyDischargeData(hostname,port,dbName,DischargeExcelPrefix,Discharge
         siteFile = r'%s%d.xls' % (DischargeExcelPrefix, year)
         print siteFile
         ImportOneYear(year, db, siteFile)
+
+def ImportMeasurementData():
+    '''
+    This function mainly to import measurement data to mongoDB
+    data type may include Q (discharge, m3/s), totalN, totalP, etc.
+    TODO: LJ
+    '''
+    print "TODO"

--- a/preprocess/build_db.py
+++ b/preprocess/build_db.py
@@ -41,7 +41,7 @@ def BuildMongoDB(workingDir, modelName, stormMode, forCluster, \
         conn.drop_database(modelName)
     db = conn[modelName]
 
-    ImportParameters(sqliteFile, db)
+    ImportParameters(sqliteFile, db)  ## import parameters.db3 to mongoDB
     f.write("10, Generating reach table...\n")
     f.flush()
     GenerateReachTable(workingDir, db, forCluster)

--- a/preprocess/main.py
+++ b/preprocess/main.py
@@ -19,18 +19,16 @@ from parameters_extraction import ExtractParameters
 from build_db import BuildMongoDB
 if __name__ == "__main__":
     ## Update SQLite Parameters.db3 database
-    #reConstructSQLiteDB()
+    reConstructSQLiteDB()
     ## Climate Data
-    #SitesMList, SitesPList = ImportHydroClimateSitesInfo(HOSTNAME,PORT,ClimateDBName,HydroClimateVarFile, MetroSiteFile, PrecSiteFile)
-    #ImportDailyMeteoData(HOSTNAME, PORT, ClimateDBName, MeteoDailyFile, SitesMList)
-    #ImportDailyPrecData(HOSTNAME,PORT,ClimateDBName,PrecExcelPrefix,PrecDataYear, SitesPList)
-    ## TODO: Measurement Data
-    #ImportDailyDischargeData(HOSTNAME,PORT,ClimateDBName,DischargeExcelPrefix,DischargeYear)
+    SitesMList, SitesPList = ImportHydroClimateSitesInfo(HOSTNAME,PORT,ClimateDBName,HydroClimateVarFile, MetroSiteFile, PrecSiteFile)
+    ImportDailyMeteoData(HOSTNAME, PORT, ClimateDBName, MeteoDailyFile, SitesMList)
+    ImportDailyPrecData(HOSTNAME,PORT,ClimateDBName,PrecExcelPrefix,PrecDataYear, SitesPList)
+    ## TODO: Measurements Data, i.e., DB_TAB_MEASUREMENT, field design refers to DB_TAB_DATAVALUES
+    ImportDailyDischargeData(HOSTNAME,PORT,ClimateDBName,DischargeExcelPrefix,DischargeYear)
     ## Spatial Data derived from DEM
-    #SubbasinDelineation(np, WORKING_DIR, dem, outlet_file, threshold, mpiexeDir=MPIEXEC_DIR,exeDir=CPP_PROGRAM_DIR)
-    #GenerateSubbasins(WORKING_DIR, exeDir=CPP_PROGRAM_DIR)
-    ## Soil chemical properties initialization
-
+    SubbasinDelineation(np, WORKING_DIR, dem, outlet_file, threshold, mpiexeDir=MPIEXEC_DIR,exeDir=CPP_PROGRAM_DIR)
+    GenerateSubbasins(WORKING_DIR, exeDir=CPP_PROGRAM_DIR)
     ## Extract parameters from landuse, soil properties etc.
     ExtractParameters(landuseFile, WORKING_DIR, True, True, True, True)
     ## Import to MongoDB database

--- a/preprocess/parameters_extraction.py
+++ b/preprocess/parameters_extraction.py
@@ -21,17 +21,17 @@ import types
 def soil_parameters2(dstdir, maskFile, soilSEQNTif, soilSEQNTxt):
     soilSEQNData = ReadDataItemsFromTxt(soilSEQNText)
     defaultSoilType = float(soilSEQNData[1][0])
-    # ## Mask soil_SEQN tif
-    # configFile = "%s%smaskSoilConfig.txt" % (dstdir, os.sep)
-    # fMask = open(configFile, 'w')
-    # fMask.write(maskFile+"\n")
-    # fMask.write("%d\n" % (1,))
+    ## Mask soil_SEQN tif
+    configFile = "%s%smaskSoilConfig.txt" % (dstdir, os.sep)
+    fMask = open(configFile, 'w')
+    fMask.write(maskFile+"\n")
+    fMask.write("%d\n" % (1,))
     soiltypeFile = dstdir + os.sep + soiltypeMFile
-    # s = "%s\t%d\t%s\n" % (soilSEQNTif, defaultSoilType, soiltypeFile)
-    # fMask.write(s)
-    # fMask.close()
-    # s = "%s/mask_raster %s" % (CPP_PROGRAM_DIR, configFile)
-    # os.system(s)
+    s = "%s\t%d\t%s\n" % (soilSEQNTif, defaultSoilType, soiltypeFile)
+    fMask.write(s)
+    fMask.close()
+    s = "%s/mask_raster %s" % (CPP_PROGRAM_DIR, configFile)
+    os.system(s)
 
     ## Read soil properties from txt file
     soilInstances = []

--- a/preprocess/soil_param.py
+++ b/preprocess/soil_param.py
@@ -44,7 +44,7 @@ class SoilProperty:
         self.Poreindex= []
         self.USLE_K = []
         self.Sol_ALB    = []
-        self.Texture    = DEFAULT_NODATA
+        self.Soil_Texture    = DEFAULT_NODATA
         self.Hydro_Group= DEFAULT_NODATA
         #self.Residue     = [] TODO: residue should be defined in Management module or dependent on landuse
         ### Here after are soil chemical properties
@@ -178,9 +178,9 @@ class SoilProperty:
                 d = (1-0.25*sn/(sn+exp(-5.51+22.9*sn)))
                 k = a * b * c * d
                 self.USLE_K.append(k)
-        if self.Texture == DEFAULT_NODATA or self.Hydro_Group == DEFAULT_NODATA:
+        if self.Soil_Texture == DEFAULT_NODATA or self.Hydro_Group == DEFAULT_NODATA:
             st, hg, uslek = GetTexture(self.CLAY[0], self.SILT[0], self.SAND[0])
-            self.Texture = st
+            self.Soil_Texture = st
             self.Hydro_Group = hg
         ### Here after is initialization of soil chemical properties. Algorithms from SWAT.
         ### Prepared by Huiran Gao

--- a/preprocess/text.py
+++ b/preprocess/text.py
@@ -49,7 +49,7 @@ SOL_P_INDEX = "Poreindex"
 SOL_USLE_K  = "USLE_K"
 SOL_ALB     = "Sol_ALB"
 #SOL_RM      = "Residual"
-SOL_TEXTURE = "Texture"
+SOL_TEXTURE = "soil_Texture"
 ## soil chemical properties
 
 ## Climate datatype tags, MUST BE coincident with text.h in SEIMS
@@ -108,7 +108,7 @@ DB_TAB_LOOKUP_SOIL = "SoilLookup"
 DB_TAB_SPATIAL = "spatial"
 DB_TAB_SITES = "Sites"
 DB_TAB_DATAVALUES = "DataValues"
-DB_TAB_MEASUREMENT = "measurement"
+DB_TAB_MEASUREMENT = "Measurements"
 DB_TAB_SITELIST = "SiteList"
 DB_TAB_REACH = "reaches"
 
@@ -220,7 +220,7 @@ HEADER_RS_NCOLS =	"NCOLS"
 HEADER_RS_CELLSIZE ="CELLSIZE"
 
 ## Fields in parameter table of MongoDB
-PARAM_FLD_NAME =    "SNAM"
+PARAM_FLD_NAME =    "NAME"
 PARAM_FLD_DESC =    "DESCRIPTION"
 PARAM_FLD_UNIT =    "UNIT"
 PARAM_FLD_MODS =    "MODULE"

--- a/src/base/util/text.h
+++ b/src/base/util/text.h
@@ -807,7 +807,7 @@
 #define DESC_RadianSlope  "radian slope"
 #define DESC_RCA "concentration of ammonia in the rain"
 #define DESC_RCN "concentration of nitrate in the rain"
-#define DESC_Reinfiltration 
+#define DESC_Reinfiltration "TODO: meaning?"
 #define DESC_RETURNFLOW "water depth of return flow"
 #define DESC_REVAP "Revap"
 #define DESC_RM "Relative humidity"
@@ -817,7 +817,6 @@
 #define DESC_ROCTL "amount of phosphorus moving from the active mineral pool to the stable mineral pool in the soil profile on the current day in cell"
 #define DESC_ROOTDEPTH "depth to bottom of soil layer"
 #define DESC_ROUTING_LAYERS "Routing layers according to the flow direction, there are no flow relationships within each layer, and the first element in each layer is the number of cells in the layer"
-#define DESC_ROUTING_LAYERS "Routing layers according to the flow direction. There are not flow relationships within each layer"
 #define DESC_RUNOFF_CO "Potential runoff coefficient"
 #define DESC_RWNTL "amount of nitrogen moving from active organic to stable organic pool in soil profile on current day in cell"
 #define DESC_SAND "Percent of sand content"

--- a/src/modules/erosion/SEDR_VCD/api.cpp
+++ b/src/modules/erosion/SEDR_VCD/api.cpp
@@ -36,7 +36,7 @@ extern "C" SEIMS_MODULE_API const char* MetadataInformation()
 #endif
 	mdi.AddParameter(VAR_P_RF,UNIT_NON_DIM, DESC_P_RF,Source_ParameterDB, DT_Single);
 	mdi.AddParameter(VAR_SPCON,UNIT_NON_DIM, DESC_SPCON,Source_ParameterDB, DT_Single);
-	mdi.AddParameter(VAR_SPEXP,UNIT_NON_DIM, ,Source_ParameterDB, DT_Single);
+	mdi.AddParameter(VAR_SPEXP,UNIT_NON_DIM,DESC_SPEXP ,Source_ParameterDB, DT_Single);
 	mdi.AddParameter(VAR_VCRIT,UNIT_SPEED_MS, DESC_VCRIT,Source_ParameterDB, DT_Single);
 	mdi.AddParameter(VAR_CHS0, UNIT_STRG_M3M, DESC_CHS0, Source_ParameterDB, DT_Single);
 	mdi.AddParameter(Tag_RchParam,UNIT_NON_DIM,DESC_REACH_PARAMETER, Source_ParameterDB,DT_Array2D);

--- a/src/modules/erosion/SPLASHERO_PARK/api.cpp
+++ b/src/modules/erosion/SPLASHERO_PARK/api.cpp
@@ -44,7 +44,7 @@ extern "C" SEIMS_MODULE_API const char* MetadataInformation()
 	mdi.AddInput(VAR_QOVERLAND,UNIT_FLOW_CMS,DESC_QOVERLAND,Source_Module,DT_Raster1D);	
 	mdi.AddInput(VAR_NEPR,UNIT_DEPTH_MM,DESC_NEPR,Source_Module,DT_Raster1D);	//Rain, from interception module
 	// set the output variables
-	mdi.AddOutput(VAR_DETSPLASH,UNIT_KG, , DT_Raster1D);
+	mdi.AddOutput(VAR_DETSPLASH,UNIT_KG,DESC_DETSPLASH , DT_Raster1D);
 
 	mdi.AddDependency(MCLSDESC_INTERC, MCLSDESC_INTERC);      //for pNet, Leafdrain
 	mdi.AddDependency(MCLS_OL_ROUTING, MCLSDESC_OL_ROUTING); 

--- a/src/modules/hydrology/IKW_IF/InterFlow_IKW.h
+++ b/src/modules/hydrology/IKW_IF/InterFlow_IKW.h
@@ -13,13 +13,13 @@
 #include <map>
 #include "SimulationModule.h"
 using namespace std;
-/** \defgroup InterFlow_IKW
+/** \defgroup IKW_IF
  * \ingroup Hydrology
  * \brief Interflow routing using implicit finite difference method
  */
 /*!
  * \class InterFlow_IKW
- * \ingroup InterFlow_IKW
+ * \ingroup IKW_IF
  *
  * \brief Interflow routing using implicit finite difference method
  *

--- a/src/modules/hydrology/IKW_OL/api.cpp
+++ b/src/modules/hydrology/IKW_OL/api.cpp
@@ -51,7 +51,7 @@ extern "C" SEIMS_MODULE_API const char* MetadataInformation()
 	mdi.AddOutput(VAR_QOVERLAND,UNIT_FLOW_CMS,DESC_QOVERLAND, DT_Raster1D);
 
 	mdi.AddOutput(VAR_Reinfiltration, UNIT_DEPTH_MM,DESC_Reinfiltration, DT_Raster1D);
-	mdi.AddOutput(VAR_FLOWWIDTH,UNIT_LEN_M,DESC_FLOWWIDTH , DT_Raster1D);
+	mdi.AddOutput(VAR_FLOWWIDTH,UNIT_LEN_M,DESC_FLOWWIDTH, DT_Raster1D);
 	mdi.AddOutput("ChWidth", "m", "Flow length of overland plane", DT_Raster1D);  //Flowlen add by Wu hui  /// TODO Figure out what's meaning? LJ
 	
 	mdi.AddOutput(VAR_RadianSlope, UNIT_NON_DIM,DESC_RadianSlope, DT_Raster1D);

--- a/src/modules/hydrology_longterm/PET_H/api.cpp
+++ b/src/modules/hydrology_longterm/PET_H/api.cpp
@@ -56,7 +56,7 @@ extern "C" SEIMS_MODULE_API const char* MetadataInformation()
 	mdi.AddOutput(VAR_PET_T,UNIT_WTRDLT_MMD, DESC_PET_T, DT_Array1D);
 
 	// set the dependencies, does this necessary? LJ
-	mdi.AddDependency(MID_ICLIM, MDESC_ICLIM);
+	mdi.AddDependency(MCLS_CLIMATE, MCLSDESC_CLIMATE);
 
 	string res = mdi.GetXMLDocument();
 

--- a/src/modules/hydrology_longterm/SUR_MR/SUR_MR.cpp
+++ b/src/modules/hydrology_longterm/SUR_MR/SUR_MR.cpp
@@ -4,8 +4,6 @@
 #include "MetadataInfo.h"
 #include "ModelException.h"
 #include "util.h"
-
-
 #include <omp.h>
 
 SUR_MR::SUR_MR(void):m_infil(NULL),m_pe(NULL), m_dt(-1), m_nSoilLayers(2),


### PR DESCRIPTION
在更新土壤数据的时候，我发现之前的代码通过土壤、土地利用和作物查找表生成相关TIFF的时候，用的都是双层for循环，这样效率很低，而Numpy提供了快速的数组操作，而且土壤数据为类型数据输入，土地利用也是一样，因此，仅需通过查找表即可，具体请参考 `soil_param.py`。

## TODO

+ 1. Landuse parameters 参考土壤进行改进
+ 2. Crop parameters 参考土壤进行改进

@liujunzhi321  @gaohr  @Shenfang1993 