### PR TITLE
update nutrient modules

### DIFF
--- a/doc/TODO.md
+++ b/doc/TODO.md
@@ -164,7 +164,13 @@ Hydrology_longterm|SUR_CN|VAR_SOMO|AddOutput
 
 ### 涉及土壤层的计算，增加NoData值的判断
 
-
+### SWAT中的未知变量和没有数据的变量：
+模块|子模块|变量名|问题
+---|---|---|---
+Nutrient|NutrientRemviaSr|qtile|没有数据,赋初值为0.0001
+Nutrient|NutrientRemviaSr|ldrain|没有数据,赋初值为-1
+Nutrient|NutrientRemviaSr|sol_preco|没有数据,赋初值为0.0001
+Nutrient|SurrunoffTransfer|sol_mp|未知变量,赋初值为0
 
 
 

--- a/src/modules/ecology/MGT_SWAT/managementOperation_SWAT.cpp
+++ b/src/modules/ecology/MGT_SWAT/managementOperation_SWAT.cpp
@@ -192,7 +192,7 @@ void MGTOpt_SWAT::initializeTillageLookup()
 }
 void MGTOpt_SWAT::initialPlantOutputs()
 {
-	if(m_BiomassTarg != NULL) Initialize1DArray(m_nCells, m_BiomassTarg, 0.);
+	if(m_BiomassTarg != NULL) Initialize1DArray(m_nCells, m_BiomassTarg, (float)0.);
 }
 void MGTOpt_SWAT::ExecutePlantOperation(int i, int& factoryID, int nOp)
 {

--- a/src/modules/nutrient/NutRemv/NutrientRemviaSr.cpp
+++ b/src/modules/nutrient/NutRemv/NutrientRemviaSr.cpp
@@ -130,6 +130,11 @@ void NutrientRemviaSr::initialOutputs() {
 	if(m_wshd_plch < 0) {
 		m_wshd_plch = 0.;
 	}
+	// input variables
+	if(m_flat == NULL) {Initialize2DArray(m_nCells, m_soiLayers, m_flat, (float)0.0001);}
+	if(m_sol_perco == NULL) {Initialize2DArray(m_nCells, m_soiLayers, m_sol_perco, (float)0.0001);}
+	if(m_ldrain == NULL) {Initialize1DArray(m_nCells, m_ldrain, (float)-1.);}
+	m_qtile = 0.0001;
 }
 int NutrientRemviaSr::Execute() {
 	if(!this -> CheckInputData()) { 

--- a/src/modules/nutrient/SurTra/SurrunoffTransfer.cpp
+++ b/src/modules/nutrient/SurTra/SurrunoffTransfer.cpp
@@ -19,7 +19,7 @@ using namespace std;
 SurrunoffTransfer::SurrunoffTransfer(void):
 	//input 
 	m_nCells(-1), m_cellWidth(-1), m_soiLayers(-1), m_nSoilLayers(NULL), m_sedimentYield(NULL), m_surfr(NULL), m_sol_bd(NULL), m_sol_z(NULL),
-	m_sol_actp(NULL), m_sol_orgn(NULL), m_sol_orgp(NULL), m_sol_stap(NULL), m_sol_aorgn(NULL), m_sol_fon(NULL), m_sol_fop(NULL), m_sol_mp(NULL)
+	m_sol_actp(NULL), m_sol_orgn(NULL), m_sol_orgp(NULL), m_sol_stap(NULL), m_sol_aorgn(NULL), m_sol_fon(NULL), m_sol_fop(NULL), m_sol_mp(NULL), 
 	//output 
 	m_sedorgn(NULL), m_sedorgp(NULL), m_sedminpa(NULL), m_sedminps(NULL)
 {
@@ -128,6 +128,7 @@ void SurrunoffTransfer::initialOutputs() {
 			m_sedminps[i] = 0.;
 		}
 	}
+	if(m_sol_mp == NULL) {Initialize2DArray(m_nCells, m_soiLayers, m_sol_mp, (float)0.);}
 }
 int SurrunoffTransfer::Execute() {
 	if(!this -> CheckInputData()) { 


### PR DESCRIPTION
## Nutrient 模块总结
### 1. Nutrient 模块中的子模块现包括：
+ NMINRL：氮、磷固化矿化与挥发（NH3）等
+ NutRemv：硝酸盐和磷流失
+ SurTra：地表径流中的养分迁移与传输
+ ATMDEP：大气沉降（硝酸盐和氨等）
+ NutGW：地下水中的氮和磷的传输
+ NutOLRout：坡面汇流
+ NutCHRout：河道汇流

### 2. 运行顺序：
NMINRL ─>  NutRemv、SurTra、NutGW

NutRemv ─┐
SurTra ──┼─> NutOLRout ──> NutCHRout
NutGW ──┘

(MUSLE_AS、DEP_FS) ──> ATMDEP

(ITP) ──> SurTra  