### PR TITLE
重新梳理地下水养分模块NutrGW

### DIFF
--- a/preprocess/generate_stream_input.py
+++ b/preprocess/generate_stream_input.py
@@ -295,13 +295,13 @@ def GenerateReachTable(folder, db, forCluster):
             dic[REACH_BOD.upper()] = 10
             dic[REACH_ALGAE.upper()] = 0 # 10
             dic[REACH_ORGN.upper()] = 0 # 10
-            dic[REACH_NH3.upper()] = 1 # 8.
+            dic[REACH_NH3.upper()] = 0 # 1 # 8.
             dic[REACH_NO2.upper()] = 0 # 0.
-            dic[REACH_NO3.upper()] = 1 # 8.
+            dic[REACH_NO3.upper()] = 0 # 1 # 8.
             dic[REACH_ORGP.upper()] = 0 # 10.
-            dic[REACH_SOLP.upper()] = 0.1 # 0.5
-            dic[REACH_GWNO3.upper()] = 0.5 # 10.
-            dic[REACH_GWSOLP.upper()] = 0.1 # 10.
+            dic[REACH_SOLP.upper()] = 0 # 0.1 # 0.5
+            dic[REACH_GWNO3.upper()] = 0 # 0.5 # 10.
+            dic[REACH_GWSOLP.upper()] = 0 # 0.1 # 10.
 
             curFilter = {REACH_SUBBASIN.upper(): id}
             db[DB_TAB_REACH.upper()].find_one_and_replace(curFilter, dic, upsert = True)

--- a/src/modules/nutrient/NutrCH_QUAL2E/NutrCH_QUAL2E.cpp
+++ b/src/modules/nutrient/NutrCH_QUAL2E/NutrCH_QUAL2E.cpp
@@ -613,20 +613,20 @@ int NutrCH_QUAL2E::Execute()
 			RouteOut(reachIndex);
         }
 	}
-	cout<<"NUTR_QUAL2E, surNO3ToCh: "<<m_surNO3ToCh[12]<<", gwno3ToCh: "<<m_gwNO3ToCh[12]<<", ptNo3ToCh: "<<m_ptNO3ToCh[12]
-	<<", chOutNO3: "<<m_chOutNO3[12]<<", chOutNO3Conc: "<<m_chOutTNConc[12]<<", TN: "<<m_chOutTN[12]<<", TNConc: "<<m_chOutTNConc[12]<<endl;
-	cout<<"chStr_NO3: "<<m_chNO3[12]<<", chStr_NH4: "<<m_chNH4[12]<<", chStr_TN: "<<m_chTN[12]<<endl;
+	//cout<<"NUTR_QUAL2E, surNO3ToCh: "<<m_surNO3ToCh[12]<<", gwno3ToCh: "<<m_gwNO3ToCh[12]<<", ptNo3ToCh: "<<m_ptNO3ToCh[12]
+	//<<", chOutNO3: "<<m_chOutNO3[12]<<", chOutNO3Conc: "<<m_chOutTNConc[12]<<", TN: "<<m_chOutTN[12]<<", TNConc: "<<m_chOutTNConc[12]<<endl;
+	//cout<<"chStr_NO3: "<<m_chNO3[12]<<", chStr_NH4: "<<m_chNH4[12]<<", chStr_TN: "<<m_chTN[12]<<endl;
     return 0;
 }
 
 void NutrCH_QUAL2E::AddInputNutrient(int i)
 {
-	cout<<"subID: "<<i<<", initial nh4: "<<m_chNH4[i]<<", ";
+	//cout<<"subID: "<<i<<", initial nh4: "<<m_chNH4[i]<<", ";
 	/// nutrient amount from upstream routing will be accumulated to current storage
 	for (size_t j = 0; j < m_reachUpStream[i].size(); ++j)
 	{
 		int upReachId = m_reachUpStream[i][j];
-		cout<<"upSubID: "<<upReachId<<", "<<m_chOutNH4[upReachId]<<", ";
+		//cout<<"upSubID: "<<upReachId<<", "<<m_chOutNH4[upReachId]<<", ";
 		m_chOrgN[i]   += m_chOutOrgN[upReachId];
 		m_chNO3[i]    += m_chOutNO3[upReachId];
 		m_chNO2[i]    += m_chOutNO2[upReachId];
@@ -638,7 +638,7 @@ void NutrCH_QUAL2E::AddInputNutrient(int i)
 		m_chChlora[i] += m_chOutChlora[upReachId];
 		m_chAlgae[i]  += m_chOutAlgae[upReachId];
 	}
-	cout<<", added upstream, nh4: "<<m_chNH4[i]<<endl;
+	//cout<<", added upstream, nh4: "<<m_chNH4[i]<<endl;
 	/// absorbed organic N, P from overland sediment routing
 	m_chOrgN[i] += m_sedOrgNToCh[i];
 	m_chOrgP[i] += m_sedOrgPToCh[i];
@@ -785,9 +785,8 @@ void NutrCH_QUAL2E::NutrientTransform(int i)
 	float wtrOut = m_qOutCh[i] * m_dt; 
 	float wtrTotal = wtrOut + m_chStorage[i]; /// m3
 	float tmpChWtDepth = m_chWTdepth[i] - m_chWTDepthDelta[i]; /// m
-	if (tmpChWtDepth <= 0.f){
-		tmpChWtDepth = UTIL_ZERO;
-		// this situation would not happen, just in case of dividing by 0. By lj
+	if (tmpChWtDepth <= 0.01f){
+		tmpChWtDepth = 0.01f;
 	}
 	if (wtrTotal <= 0.f)/// which means no flow out of current channel    || wtrOut <= 0.f
 	{
@@ -1029,7 +1028,7 @@ void NutrCH_QUAL2E::NutrientTransform(int i)
 	float f1 = 0.f;
 	f1 = m_p_n * nh3con / (m_p_n * nh3con + (1.f - m_p_n) * no3con + 1.e-6f);
 
-	//if (i == 12) cout<<"nh3 conc: "<<nh3con<<",";
+	//cout<<"subID: "<<i<<", initial nh3 conc: "<<nh3con<<", "<<"initial orgn: "<<orgncon<<", ";
 	// calculate ammonia nitrogen concentration at end of day (dnh4)
 	ww = 0.f;
 	xx = 0.f;
@@ -1044,7 +1043,7 @@ void NutrCH_QUAL2E::NutrientTransform(int i)
 	if (dnh4 < 1.e-6f) dnh4 = 0.f;
 	if (dnh4 > dcoef * nh3con && nh3con > 0.f)
 		dnh4 = dcoef * nh3con;
-	//if (i == 12) cout<<"ww: "<<ww<<", xx: "<<xx<<", yy: "<<yy<<", zz: "<<zz<<", nh4 out: "<<dnh4<<endl;
+	//cout<<"ww: "<<ww<<", xx: "<<xx<<", yy: "<<yy<<", zz: "<<zz<<", nh4 out: "<<dnh4<<endl;
 	// calculate concentration of nitrite at end of day (dno2)
 	yy = 0.f;
 	zz = 0.f;
@@ -1083,7 +1082,7 @@ void NutrCH_QUAL2E::NutrientTransform(int i)
 	yy = 0.f;
 	zz = 0.f;
 	xx = corTempc(m_bc4[i], thbc4, wtmp) * orgpcon;
-	yy = corTempc(m_rs2[i], thrs2, wtmp) / (m_chWTdepth[i] * 1000.f);
+	yy = corTempc(m_rs2[i], thrs2, wtmp) / (tmpChWtDepth * 1000.f);
 	zz = m_ai2 * corTempc(gra, thgra, wtmp) * algcon;
 	dsolp = 0.f;
 	dsolp = solpcon + (xx + yy - zz) * tday;

--- a/src/modules/nutrient/NutrGW/NutrientinGroundwater.h
+++ b/src/modules/nutrient/NutrGW/NutrientinGroundwater.h
@@ -55,10 +55,16 @@ private:
 	int m_TimeStep;
 
     /// input data
+	/// gw0
+	float m_gw0;
     /// nitrate N concentration in groundwater loading to reach (mg/L, i.e. g/m3)
     float *m_gwno3Con;
+	/// kg
+	float *m_gwNO3; 
     /// soluble P concentration in groundwater loading to reach (mg/L, i.e. g/m3)
-    float *m_gwminpCon;
+    float *m_gwSolCon;
+	/// kg
+	float *m_gwSolP;
     /// groundwater contribution to stream flow (m3/s)
     float *m_gw_q; 
 	/// groundwater storage
@@ -82,9 +88,9 @@ private:
     /// outputs
 
     /// nitrate loading to reach in groundwater to channel
-    float *m_no3gwToCh;
+    float *m_no3GwToCh;
     /// soluble P loading to reach in groundwater to channel
-    float *m_minpgwToCh;
+    float *m_solpGwToCh;
 
 	/// subbasin related
 	/// the total number of subbasins

--- a/src/modules/nutrient/NutrMV/NutrientRemviaSr.h
+++ b/src/modules/nutrient/NutrMV/NutrientRemviaSr.h
@@ -138,11 +138,11 @@ private:
     //float* m_soxy;
 
 	// N and P to channel
-	float *m_latno3ToCh;  // amount of nitrate transported with lateral flow to channel
-	float *m_sur_no3ToCh; // amount of nitrate transported with surface runoff to channel
-	float *m_sur_solpToCh;// amount of soluble phosphorus in surface runoff to channel
-	float *m_perco_n_gw;  // amount of nitrate percolating past bottom of soil profile sum by sub-basin
-	float *m_perco_p_gw;  // amount of solute P percolating past bottom of soil profile sum by sub-basin
+	float *m_latno3ToCh;  // amount of nitrate transported with lateral flow to channel, kg
+	float *m_sur_no3ToCh; // amount of nitrate transported with surface runoff to channel, kg
+	float *m_sur_solpToCh;// amount of soluble phosphorus in surface runoff to channel, kg
+	float *m_perco_n_gw;  // amount of nitrate percolating past bottom of soil profile sum by sub-basin, kg
+	float *m_perco_p_gw;  // amount of solute P percolating past bottom of soil profile sum by sub-basin, kg
 
 	// amount of COD to reach in surface runoff (kg)
 	float *m_sur_codToCh; 


### PR DESCRIPTION
+ 1.还原当天地下水全部容积（包括地下径流、再蒸发流失的水量，此时渗漏的水量已经加进去，不作重复考虑）
+ 2.更新地下水养分含量、浓度
+ 3.计算地下径流损失养分含量
+ 4.计算再蒸发损失养分，并更新最下层土壤养分浓度
+ 5.更新养分含量 (kg)

> 目前上传的为粗略版本