### PR TITLE
修复IMP_SWAT等模块bug

### DIFF
--- a/model_data/dianbu/model_dianbu_30m_longterm/file.out
+++ b/model_data/dianbu/model_dianbu_30m_longterm/file.out
@@ -95,7 +95,7 @@ NutrientTransport	SEDORGNTOCH	organic nitrogen in surface runoff moved to channe
 NutrientTransport	SEDORGPTOCH	organic phosphorus in surface runoff moved to channel	kg/ha	NONE	2013-01-01 00:00	2014-12-31 23:59	-9999	-9999	OUTLET	SEDORGPTOCH.txt	1
 NutrientTransport	SEDMINPATOCH	active mineral phosphorus sorbed to sediment in surface runoff moved to channel	kg/ha	NONE	2013-01-01 00:00	2014-12-31 23:59	-9999	-9999	OUTLET	SEDMINPATOCH.txt	1
 NutrientTransport	SEDMINPSTOCH	stable mineral phosphorus sorbed to sediment in surface runoff moved to channel	kg/ha	NONE	2013-01-01 00:00	2014-12-31 23:59	-9999	-9999	OUTLET	SEDMINPSTOCH.txt	1
-NutrientTransport	COD	carbonaceous oxygen demand of surface runoff	kg/ha	SUM,AVE	2013-01-01 00:00	2014-12-31 23:59	-9999	-9999	ALL	COD.tif	1
+NutrientTransport	SUR_COD	carbonaceous oxygen demand of surface runoff	kg/ha	SUM,AVE	2013-01-01 00:00	2014-12-31 23:59	-9999	-9999	ALL	SUR_COD.tif	1
 NutrientTransport	SUR_NO3	nitrate transported with surface runoff	kg/ha	SUM,AVE	2013-01-01 00:00	2014-12-31 23:59	-9999	-9999	ALL	SUR_NO3.tif	1
 NutrientTransport	SUR_SOLP	phosphorus stored in solution with surface runoff	kg/ha	SUM,AVE	2013-01-01 00:00	2014-12-31 23:59	-9999	-9999	ALL	SUR_SOLP.tif	1
 NutrientTransport	LATNO3	nitrate transported with lateral flow	kg/ha	SUM,AVE	2013-01-01 00:00	2014-12-31 23:59	-9999	-9999	ALL	LATNO3.tif	1

--- a/src/base/util/text.h
+++ b/src/base/util/text.h
@@ -600,8 +600,7 @@
 #define VAR_CN2 "CN2"
 #define VAR_CO2 "Co2"                                 /// CO2 Concentration
 #define VAR_CO2HI "CO2HI"
-#define VAR_COD_CH "codToCh"
-#define VAR_COD "cod"
+#define VAR_SUR_COD "sur_cod"
 #define VAR_COD_N "cod_n"
 #define VAR_COD_K "cod_k"
 #define VAR_COND_MAX "Cond_max"                       /// "Maximum automata's conductance"
@@ -1226,7 +1225,7 @@
 #define DESC_CN2 "CN under moisture condition II"
 #define DESC_CO2 "CO2 Concentration"
 #define DESC_CO2HI "elevated CO2 atmospheric concentration corresponding the 2nd point on the radiation use efficiency curve"
-#define DESC_COD "carbonaceous oxygen demand of surface runoff"
+#define DESC_SUR_COD "carbonaceous oxygen demand of surface runoff"
 #define DESC_COD_CH "carbonaceous oxygen demand loading to reach"
 #define DESC_COD_N "Conversion factor"
 #define DESC_COD_K "Reaction coefficient"

--- a/src/modules/erosion/SEDR_SBAGNOLD/api.cpp
+++ b/src/modules/erosion/SEDR_SBAGNOLD/api.cpp
@@ -45,14 +45,16 @@ extern "C" SEIMS_MODULE_API const char *MetadataInformation()
 	mdi.AddParameter(VAR_REACH_PARAM, UNIT_NON_DIM, DESC_REACH_PARAM, Source_ParameterDB, DT_Reach);
 	/// load point source loading sediment from Scenario
 	mdi.AddParameter(VAR_SCENARIO, UNIT_NON_DIM, DESC_SCENARIO, Source_ParameterDB, DT_Scenario);
-    mdi.AddInput(VAR_SED_TO_CH, UNIT_KG, DESC_SED_TO_CH, Source_Module, DT_Array1D);
+    
+	mdi.AddInput(VAR_SED_TO_CH, UNIT_KG, DESC_SED_TO_CH, Source_Module, DT_Array1D);
     mdi.AddInput(VAR_QRECH, UNIT_FLOW_CMS, DESC_QRECH, Source_Module, DT_Array1D);
     mdi.AddInput(VAR_CHST, UNIT_VOL_M3, DESC_CHST, Source_Module, DT_Array1D);
 	mdi.AddInput(VAR_PRECHST, UNIT_VOL_M3, DESC_PRECHST, Source_Module, DT_Array1D);
     mdi.AddInput(VAR_CHWTDEPTH, UNIT_LEN_M, DESC_CHWTDEPTH, Source_Module, DT_Array1D);
 	mdi.AddInput(VAR_PRECHWTDEPTH, UNIT_LEN_M, DESC_PRECHWTDEPTH, Source_Module, DT_Array1D);
 	mdi.AddInput(VAR_CHWTWIDTH, UNIT_LEN_M, DESC_CHWTWIDTH, Source_Module, DT_Array1D);
-    mdi.AddOutput(VAR_SED_RECH, UNIT_KG, DESC_SED_RECH, DT_Array1D);
+    
+	mdi.AddOutput(VAR_SED_RECH, UNIT_KG, DESC_SED_RECH, DT_Array1D);
 	mdi.AddOutput(VAR_SED_RECHConc, UNIT_SEDCONC, DESC_SED_RECH, DT_Array1D);
     mdi.AddOutput(VAR_SED_OUTLET, UNIT_KG, DESC_SED_OUTLET, DT_Single);
 

--- a/src/modules/hydrology_longterm/IMP_SWAT/api.cpp
+++ b/src/modules/hydrology_longterm/IMP_SWAT/api.cpp
@@ -70,11 +70,25 @@ extern "C" SEIMS_MODULE_API const char *MetadataInformation()
 	mdi.AddInput(VAR_SUR_NO3, UNIT_CONT_KGHA, DESC_SUR_NO3, Source_Module, DT_Raster1D);
 	mdi.AddInput(VAR_SUR_NH4, UNIT_CONT_KGHA, DESC_SUR_NH4, Source_Module, DT_Raster1D);
 	mdi.AddInput(VAR_SUR_SOLP, UNIT_CONT_KGHA, DESC_SUR_SOLP, Source_Module, DT_Raster1D);
+	mdi.AddInput(VAR_SUR_COD, UNIT_CONT_KGHA, DESC_SUR_COD, Source_Module, DT_Raster1D);
 	mdi.AddInput(VAR_SEDORGN, UNIT_CONT_KGHA, DESC_SEDORGN, Source_Module, DT_Raster1D);
 	mdi.AddInput(VAR_SEDORGP, UNIT_CONT_KGHA, DESC_SEDORGP, Source_Module, DT_Raster1D);
 	mdi.AddInput(VAR_SEDMINPA, UNIT_CONT_KGHA, DESC_SEDMINPA, Source_Module, DT_Raster1D);
 	mdi.AddInput(VAR_SEDMINPS, UNIT_CONT_KGHA, DESC_SEDMINPS, Source_Module, DT_Raster1D);
-    /// set the output variables
+    
+
+	mdi.AddInput(VAR_SBOF, UNIT_FLOW_CMS, DESC_SBOF, Source_Module, DT_Array1D);
+	mdi.AddInput(VAR_SED_TO_CH, UNIT_KG, DESC_SED_TO_CH, Source_Module, DT_Array1D);
+	mdi.AddInput(VAR_SUR_NO3_TOCH, UNIT_KG, DESC_SUR_NO3_ToCH, Source_Module, DT_Array1D);
+	mdi.AddInput(VAR_SUR_NH4_TOCH, UNIT_KG, DESC_SUR_NH4_ToCH, Source_Module, DT_Array1D);
+	mdi.AddInput(VAR_SUR_SOLP_TOCH, UNIT_KG, DESC_SUR_SOLP_ToCH, Source_Module, DT_Array1D);
+	mdi.AddInput(VAR_SUR_COD_TOCH, UNIT_KG, DESC_SUR_COD_ToCH, Source_Module, DT_Array1D);
+	mdi.AddInput(VAR_SEDORGN_TOCH, UNIT_KG, DESC_SEDORGN_CH, Source_Module, DT_Array1D);
+	mdi.AddInput(VAR_SEDORGP_TOCH, UNIT_KG, DESC_SEDORGP_CH, Source_Module, DT_Array1D);
+	mdi.AddInput(VAR_SEDMINPA_TOCH, UNIT_KG, DESC_SEDMINPA_CH, Source_Module, DT_Array1D);
+	mdi.AddInput(VAR_SEDMINPS_TOCH, UNIT_KG, DESC_SEDMINPS_CH, Source_Module, DT_Array1D);
+	
+	/// set the output variables
 	mdi.AddOutput(VAR_POT_NO3, UNIT_KG, DESC_POT_NO3, DT_Raster1D);
 	mdi.AddOutput(VAR_POT_NH4, UNIT_KG, DESC_POT_NH4, DT_Raster1D);
 	mdi.AddOutput(VAR_POT_ORGN, UNIT_KG, DESC_POT_ORGN, DT_Raster1D);

--- a/src/modules/hydrology_longterm/IMP_SWAT/pothole_SWAT.h
+++ b/src/modules/hydrology_longterm/IMP_SWAT/pothole_SWAT.h
@@ -1,11 +1,13 @@
 /*!
-* \brief Simulates depressional areas that do not drain to the stream network (pothole) and impounded areas such as rice paddies
+ * \brief Simulates depressional areas that do not drain to the stream network (pothole) and impounded areas such as rice paddies
  * \author Liang-Jun Zhu
  * \date Sep 2016
  *           1. Source code of SWAT include: pothole.f
  *           2. Add the simulation of Ammonia n transported with surface runoff, 2016-9-27
  *           3. Add m_depEvapor and m_depStorage from DEP_LENSLEY module
  *           4. Using a simple model (first-order kinetics equation) to simulate N transformation in impounded area.
+ * \data 2016-10-10
+ * \description: 1. Update all related variables after the simulation of pothole.
  */
 #pragma once
 
@@ -90,8 +92,6 @@ private:
 	float *m_surfaceRunoff;
 	/// sediment yield transported on each cell, kg
 	float *m_sedYield;
-	/// sediment yield transported to channel, kg
-	float *m_sedToCh;
 	//! sand yield
 	float *m_sandYield;
 	//! silt yield
@@ -112,6 +112,8 @@ private:
 	float *m_surqNH4;
 	/// amount of soluble phosphorus transported with surface runoff
 	float *m_surqSolP;
+	/// 
+	float *m_surqCOD;
 	/// 
 	float *m_sedOrgN;
 	///
@@ -173,6 +175,30 @@ private:
 	//float *m_potSagIn;
 	///// large aggregate
 	//float *m_potLagIn;
+
+	/* 
+	 * surface runoff, sediment, nutrient that into the channel
+	 */
+	/// surface runoff to channel, m^3/s
+	float *m_surfqToCh;
+	/// sediment transported to channel, kg
+	float *m_sedToCh;
+	/// amount of nitrate transported with surface runoff
+	float *m_surNO3ToCh;
+	/// amount of ammonian transported with surface runoff
+	float *m_surNH4ToCh;
+	/// amount of soluble phosphorus in surface runoff
+	float *m_surSolPToCh;
+	/// cod to reach in surface runoff (kg)
+	float *m_surCodToCh;
+	// amount of organic nitrogen in surface runoff
+	float *m_sedOrgNToCh;
+	// amount of organic phosphorus in surface runoff
+	float *m_sedOrgPToCh;
+	// amount of active mineral phosphorus absorbed to sediment in surface runoff
+	float *m_sedMinPAToCh;
+	// amount of stable mineral phosphorus absorbed to sediment in surface runoff
+	float *m_sedMinPSToCh;
 
 public:
     //! Constructor

--- a/src/modules/hydrology_longterm/IUH_OL/IUH_OL.h
+++ b/src/modules/hydrology_longterm/IUH_OL/IUH_OL.h
@@ -82,7 +82,7 @@ private:
     int m_nCells;
     /// cell width of the grid (m)
     float m_CellWidth;
-	/// cell area
+	/// cell area, BE CAUTION, the unit is m^2, NOT ha!!!
 	float m_cellArea;
     /// the total number of subbasins
 	int m_nSubbasins;

--- a/src/modules/nutrient/NutrCH_QUAL2E/NutrCH_QUAL2E.cpp
+++ b/src/modules/nutrient/NutrCH_QUAL2E/NutrCH_QUAL2E.cpp
@@ -23,7 +23,7 @@ NutrCH_QUAL2E::NutrCH_QUAL2E(void) :
 		m_chWTdepth(NULL), m_preChWTDepth(NULL), m_chTemp(NULL),
         m_latNO3ToCh(NULL), m_surNO3ToCh(NULL), m_surNH4ToCh(NULL), m_surSolPToCh(NULL), m_gwNO3ToCh(NULL),
         m_gwSolPToCh(NULL), m_sedOrgNToCh(NULL), m_sedOrgPToCh(NULL), m_sedMinPAToCh(NULL),
-        m_sedMinPSToCh(NULL), m_nh4ToCh(NULL), m_no2ToCh(NULL), m_codToCh(NULL),
+        m_sedMinPSToCh(NULL), m_no2ToCh(NULL), m_surCodToCh(NULL),
 		m_chSr(NULL), m_chDaylen(NULL), m_chCellCount(NULL), m_soilTemp(NULL),
 		// reaches related
 		m_reachDownStream(NULL), m_chOrgNCo(NODATA_VALUE), m_chOrgPCo(NODATA_VALUE),
@@ -224,7 +224,7 @@ bool NutrCH_QUAL2E::CheckInputData()
     CHECK_POINTER(MID_NUTRCH_QUAL2E, m_latNO3ToCh, "m_latNO3ToCh")
     CHECK_POINTER(MID_NUTRCH_QUAL2E, m_surNO3ToCh, "m_surNO3ToCh")
 	CHECK_POINTER(MID_NUTRCH_QUAL2E, m_surSolPToCh, "m_surSolPToCh")
-	CHECK_POINTER(MID_NUTRCH_QUAL2E, m_codToCh, "m_codToCh")
+	CHECK_POINTER(MID_NUTRCH_QUAL2E, m_surCodToCh, "m_codToCh")
     CHECK_POINTER(MID_NUTRCH_QUAL2E, m_gwNO3ToCh, "m_gwNO3ToCh")
 	CHECK_POINTER(MID_NUTRCH_QUAL2E, m_gwSolPToCh, "m_gwSolPToCh")
 	CHECK_POINTER(MID_NUTRCH_QUAL2E, m_sedOrgNToCh, "m_sedOrgNToCh")
@@ -339,14 +339,13 @@ void NutrCH_QUAL2E::Set1DData(const char *key, int n, float *data)
 	else if (StringMatch(sk, VAR_SUR_NO3_TOCH))  { m_surNO3ToCh = data; }
 	else if (StringMatch(sk, VAR_SUR_NH4_TOCH))  { m_surNH4ToCh = data; }
 	else if (StringMatch(sk, VAR_SUR_SOLP_TOCH)) { m_surSolPToCh = data; }
-	else if (StringMatch(sk, VAR_SUR_COD_TOCH))  { m_codToCh = data; }
+	else if (StringMatch(sk, VAR_SUR_COD_TOCH))  { m_surCodToCh = data; }
     else if (StringMatch(sk, VAR_NO3GW_TOCH))    { m_gwNO3ToCh = data; }
     else if (StringMatch(sk, VAR_MINPGW_TOCH))   { m_gwSolPToCh = data; }
     else if (StringMatch(sk, VAR_SEDORGN_TOCH))  { m_sedOrgNToCh = data; }
     else if (StringMatch(sk, VAR_SEDORGP_TOCH))  { m_sedOrgPToCh = data; }
     else if (StringMatch(sk, VAR_SEDMINPA_TOCH)) { m_sedMinPAToCh = data; }
     else if (StringMatch(sk, VAR_SEDMINPS_TOCH)) { m_sedMinPSToCh = data; }
-    else if (StringMatch(sk, VAR_SUR_NH4_TOCH))  { m_nh4ToCh = data; }
     else if (StringMatch(sk, VAR_NO2_TOCH))      { m_no2ToCh = data; }
 	else if (StringMatch(sk, VAR_RCH_DEG)) m_chDeg = data;
     else
@@ -654,14 +653,13 @@ void NutrCH_QUAL2E::AddInputNutrient(int i)
 	}
 	/// dissolved N, P from overland surface flow routing and groundwater
 	m_chNO3[i]  += m_surNO3ToCh[i] + m_latNO3ToCh[i] + m_gwNO3ToCh[i];
-	if (m_surNH4ToCh != NULL && m_surNH4ToCh[i] > 0.f)
-		m_chNH4[i] += m_surNH4ToCh[i];
+	if (m_surNH4ToCh != NULL && m_surNH4ToCh[i] > 0.f) m_chNH4[i] += m_surNH4ToCh[i];
 	m_chSolP[i] += m_surSolPToCh[i] + m_gwSolPToCh[i];
 
-	if(m_nh4ToCh != NULL && m_nh4ToCh[i] > 0.f) m_chNH4[i] += m_nh4ToCh[i];
+	// if(m_nh4ToCh != NULL && m_nh4ToCh[i] > 0.f) m_chNH4[i] += m_nh4ToCh[i];
 	if(m_no2ToCh != NULL && m_no2ToCh[i] > 0.f) m_chNO2[i] += m_no2ToCh[i];
-	if(m_codToCh != NULL && m_codToCh[i] > 0.f){
-		m_chCOD[i] += m_codToCh[i];
+	if(m_surCodToCh != NULL && m_surCodToCh[i] > 0.f){
+		m_chCOD[i] += m_surCodToCh[i];
 		//cout<<", added surface, cod: "<<m_chCOD[i]<<", ";
 	}
 	/// add point source loadings to channel

--- a/src/modules/nutrient/NutrCH_QUAL2E/NutrCH_QUAL2E.h
+++ b/src/modules/nutrient/NutrCH_QUAL2E/NutrCH_QUAL2E.h
@@ -1,6 +1,6 @@
 /*!
  * \brief Calculates in-stream nutrient transformations with QUAL2E method.
- *        watqual.f of SWAT
+ *        watqual2.f of SWAT
  * \author Huiran Gao; Junzhi Liu
  * \date Jun 2016
  *
@@ -169,6 +169,8 @@ private:
 	float *m_surNH4ToCh;
     /// amount of soluble phosphorus in surface runoff
     float *m_surSolPToCh;
+    /// cod to reach in surface runoff (kg)
+    float *m_surCodToCh;
     /// nitrate loading to reach in groundwater
     float *m_gwNO3ToCh;
     /// soluble P loading to reach in groundwater
@@ -182,11 +184,9 @@ private:
     // amount of stable mineral phosphorus absorbed to sediment in surface runoff
     float *m_sedMinPSToCh;
     /// amount of ammonium transported with lateral flow
-    float *m_nh4ToCh;
+    //float *m_nh4ToCh;
     /// amount of nitrite transported with lateral flow
     float *m_no2ToCh;
-    /// cod to reach in surface runoff (kg)
-    float *m_codToCh;
 
 	/// point source loadings (kg) to channel of each timestep
 	/// nitrate

--- a/src/modules/nutrient/NutrCH_QUAL2E/api.cpp
+++ b/src/modules/nutrient/NutrCH_QUAL2E/api.cpp
@@ -75,10 +75,8 @@ extern "C" SEIMS_MODULE_API const char *MetadataInformation()
 	mdi.AddInput(VAR_SUR_COD_TOCH, UNIT_KG, DESC_SUR_COD_ToCH, Source_Module, DT_Array1D);
 	mdi.AddInput(VAR_SEDORGN_TOCH, UNIT_KG, DESC_SEDORGN_CH, Source_Module, DT_Array1D);
 	mdi.AddInput(VAR_SEDORGP_TOCH, UNIT_KG, DESC_SEDORGP_CH, Source_Module, DT_Array1D);
-	
 	mdi.AddInput(VAR_SEDMINPA_TOCH, UNIT_KG, DESC_SEDMINPA_CH, Source_Module, DT_Array1D);
 	mdi.AddInput(VAR_SEDMINPS_TOCH, UNIT_KG, DESC_SEDMINPS_CH, Source_Module, DT_Array1D);
-	//mdi.AddInput(VAR_SUR_NH4_TOCH, UNIT_KG, DESC_SUR_NH4_CH, Source_Module, DT_Array1D);
 	//nutrient from interflow
 	mdi.AddInput(VAR_LATNO3_TOCH, UNIT_KG, DESC_LATNO3_CH, Source_Module, DT_Array1D);
 	//nutrient from ground water

--- a/src/modules/nutrient/NutrGW/NutrientinGroundwater.h
+++ b/src/modules/nutrient/NutrGW/NutrientinGroundwater.h
@@ -12,14 +12,14 @@
 #include "ModelException.h"
 
 using namespace std;
-/** \defgroup NutGW
+/** \defgroup NutrGW
  * \ingroup Nutrient
  * \brief Calculates the nitrate and soluble phosphorus loading contributed by groundwater flow.
  */
 
 /*!
  * \class NutrientinGroundwater
- * \ingroup NutGW
+ * \ingroup NutrGW
  *
  * \brief Calculates the nitrate and soluble phosphorus loading contributed by groundwater flow.
  *
@@ -120,5 +120,4 @@ private:
     bool CheckInputSize(const char *, int);
 	/// initial outputs
     void initialOutputs();
-
 };

--- a/src/modules/nutrient/NutrMV/NutrientMovementViaWater.cpp
+++ b/src/modules/nutrient/NutrMV/NutrientMovementViaWater.cpp
@@ -644,7 +644,7 @@ void NutrientMovementViaWater::Get1DData(const char *key, int *n, float **data)
 		*data = this->m_surqsolp; 
 		*n = m_nCells;
 	}
-    else if (StringMatch(sk, VAR_COD)) 
+    else if (StringMatch(sk, VAR_SUR_COD)) 
 	{
 		*data = this->m_surcod; 
 		*n = m_nCells;

--- a/src/modules/nutrient/NutrMV/api.cpp
+++ b/src/modules/nutrient/NutrMV/api.cpp
@@ -82,7 +82,7 @@ extern "C" SEIMS_MODULE_API const char *MetadataInformation()
     mdi.AddOutput(VAR_SUR_NO3, UNIT_CONT_KGHA, DESC_SUR_NO3, DT_Raster1D);
 	mdi.AddOutput(VAR_SUR_NH4, UNIT_CONT_KGHA, DESC_SUR_NH4, DT_Raster1D);
     mdi.AddOutput(VAR_SUR_SOLP, UNIT_CONT_KGHA, DESC_SUR_SOLP, DT_Raster1D);
-	mdi.AddOutput(VAR_COD, UNIT_CONT_KGHA, DESC_COD, DT_Raster1D);
+	mdi.AddOutput(VAR_SUR_COD, UNIT_CONT_KGHA, DESC_SUR_COD, DT_Raster1D);
     mdi.AddOutput(VAR_CHL_A, UNIT_CONCENTRATION, DESC_CHL_A, DT_Raster1D);
 	mdi.AddOutput(VAR_LATNO3, UNIT_CONT_KGHA, DESC_LATNO3, DT_Raster1D);
 	//to groundwater

--- a/src/modules/nutrient/NutrSED/NutrientTransportSediment.h
+++ b/src/modules/nutrient/NutrSED/NutrientTransportSediment.h
@@ -1,6 +1,8 @@
 /*!
- * \file NutrientTransportSediment.h
  * \brief Nutrient removed and lost in surface runoff.
+ *        Support three carbon model, static method (orgn.f), C-FARM one carbon model (orgncswat.f),
+ *                                    and CENTURY C/N cycling model (NCsed_leach.f90) from SWAT
+ *        As for phosphorus, psed.f of SWAT calculates the attached to sediment in surface runoff.
  * \author Huiran Gao
  * \date April 2016
  * 
@@ -20,14 +22,14 @@
 using namespace std;
 /** \defgroup NUTRSED
  * \ingroup Nutrient
- * \brief Nutrient removed and lost with the eroded and transported sediment.
+ * \brief Nutrient removed and lost with the eroded sediment in surface runoff
  */
 
 /*!
  * \class NutrientTransportSediment
  * \ingroup NUTRSED
  *
- * \brief Nutrient removed and lost with the eroded and transported sediment.
+ * \brief Nutrient removed and lost with the eroded sediment in surface runoff
  *
  */
 
@@ -130,7 +132,8 @@ private:
     float **m_sol_stap;
     //amount of phosphorus stored in the active mineral phosphorus pool, kg P/ha
     float **m_sol_actp;
-
+	/// for C-FARM one carbon model
+	float **m_sol_mp;
 	/// for CENTURY C/Y cycling model
 	/// inputs from other modules
 	float **m_sol_LSN;
@@ -165,10 +168,15 @@ private:
      */
     bool CheckInputData(void);
 	/*!
-     * \brief check the input data for running CENTURY model. Make sure all the input data is available.
-     * \return bool The validity of the input data.
+     * \brief check the input data for running CENTURY model. Make sure all the inputs data is available.
+     * \return bool The validity of the inputs data.
      */
 	bool CheckInputData_CENTURY(void);
+	/*!
+     * \brief check the input data for running C-FARM one carbon model. Make sure all the inputs data is available.
+     * \return bool The validity of the inputs data.
+     */
+	bool CheckInputData_CFARM(void);
     /*!
      * \brief check the input size. Make sure all the input data have same dimension.
      *
@@ -180,14 +188,22 @@ private:
 
     /*!
      * \brief calculates the amount of organic nitrogen removed in surface runoff.
-     * orgn.f of SWAT
+     *        orgn.f of SWAT, when CSWAT = 0
      * \return void
      */
     void OrgNRemovedInRunoff_StaticMethod(int i);
 
 	/*!
      * \brief calculates the amount of organic nitrogen removed in surface runoff.
-     * NCsed_leach.f90 of SWAT
+     *        orgnswat.f of SWAT, when CSWAT = 1
+	 * \TODO THIS IS ON TODO LIST
+     * \return void
+     */
+    void OrgNRemovedInRunoff_CFARMOneCarbonModel(int i);
+
+	/*!
+     * \brief calculates the amount of organic nitrogen removed in surface runoff.
+     *        NCsed_leach.f90 of SWAT, when CSWAT = 2
      * \return void
      */
     void OrgNRemovedInRunoff_CENTURY(int i);
@@ -198,7 +214,6 @@ private:
      * \return void
      */
     void OrgPAttachedtoSed(int i);
-
+	/// initial outputs
     void initialOutputs();
-
 };

--- a/src/modules/nutrient/NutrSed/api.cpp
+++ b/src/modules/nutrient/NutrSed/api.cpp
@@ -51,6 +51,8 @@ extern "C" SEIMS_MODULE_API const char *MetadataInformation()
     mdi.AddInput(VAR_SOL_HORGP, UNIT_CONT_KGHA, DESC_SOL_HORGP, Source_Module, DT_Raster2D);
     mdi.AddInput(VAR_SOL_ACTP, UNIT_CONT_KGHA, DESC_SOL_ACTP, Source_Module, DT_Raster2D);
     mdi.AddInput(VAR_SOL_STAP, UNIT_CONT_KGHA, DESC_SOL_STAP, Source_Module, DT_Raster2D);
+	/// for C-FARM one carbon model
+	mdi.AddInput(VAR_SOL_MP, UNIT_CONT_KGHA, DESC_SOL_MP, Source_Module_Optional, DT_Raster2D);
 
 	/// for CENTURY C/N cycling model, set as optional inputs
 	mdi.AddInput(VAR_SOL_LSN, UNIT_CONT_KGHA, DESC_SOL_LSN, Source_Module_Optional, DT_Raster2D);


### PR DESCRIPTION
+ pothole（包括水田paddy rice）模拟之后，会对当天的水、泥沙、污染物的入河量产生影响，因此需要在IMP_SWAT模块中进行重新计算
+ 这样做的好处之一是，如果模型不包含IMP_SWAT运行，依然可以，即水田模块和其他模块松耦合